### PR TITLE
change start and end position props for drawer to left and right

### DIFF
--- a/src/layers/Drawer/Drawer.module.css
+++ b/src/layers/Drawer/Drawer.module.css
@@ -46,18 +46,18 @@
     }
   }
 
-  &.start,
-  &.end {
+  &.left,
+  &.right {
     top: 0;
     bottom: 0;
     height: 100%;
   }
 
-  &.start {
+  &.left {
     left: 0;
   }
 
-  &.end {
+  &.right {
     right: 0;
   }
 

--- a/src/layers/Drawer/Drawer.tsx
+++ b/src/layers/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, ReactNode } from 'react';
+import { FC, ReactElement } from 'react';
 import classNames from 'classnames';
 import FocusTrap from 'focus-trap-react';
 import { CloneElement, GlobalOverlay, GlobalOverlayProps, useId } from 'rdk';
@@ -72,7 +72,11 @@ export const Drawer: FC<Partial<DrawerProps>> = ({
                 when: 'beforeChildren'
               }}
               style={{ ...style, zIndex: overlayIndex }}
-              className={classNames(css.drawer, className, css[position], {
+              className={classNames(css.drawer, className, {
+                [css.left]: position === 'start',
+                [css.right]: position === 'end',
+                [css.top]: position === 'top',
+                [css.bottom]: position === 'bottom',
                 [css.disablePadding]: disablePadding
               })}
             >


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`start` and `end` classNames are being dropped when reablocks is being imported through another project

Issue Number: N/A


## What is the new behavior?
avoid using these classNames

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Drawer position `start` and `end` have been changed to `left` and `right`

## Other information
