### PR TITLE
update header for dialog and drawer

### DIFF
--- a/src/layers/Dialog/Dialog.module.css
+++ b/src/layers/Dialog/Dialog.module.css
@@ -38,6 +38,7 @@
 
   .header {
     display: flex;
+    justify-content: space-between;
     padding: 20px 20px 10px 20px;
 
     .headerText {

--- a/src/layers/Dialog/Dialog.story.tsx
+++ b/src/layers/Dialog/Dialog.story.tsx
@@ -18,15 +18,26 @@ export const Simple = () => {
   );
 };
 
-const CustomHeaderElement = ({ children }: any) => <div>{children}</div>;
-
 export const CustomHeader = () => {
   const { toggleOpen, Dialog } = useDialog();
 
   return (
     <div style={{ textAlign: 'center', margin: '50px' }}>
       <button onClick={toggleOpen}>Open</button>
-      <Dialog header="My Custom Header" headerElement={<CustomHeaderElement />}>
+      <Dialog header={<h3>What's up</h3>}>Hello</Dialog>
+    </div>
+  );
+};
+
+const MyHeader = ({ children }: any) => <div>{children}</div>;
+
+export const CustomHeaderElement = () => {
+  const { toggleOpen, Dialog } = useDialog();
+
+  return (
+    <div style={{ textAlign: 'center', margin: '50px' }}>
+      <button onClick={toggleOpen}>Open</button>
+      <Dialog header="My Custom Header" headerElement={<MyHeader />}>
         Body Content
       </Dialog>
     </div>

--- a/src/layers/Dialog/DialogHeader.tsx
+++ b/src/layers/Dialog/DialogHeader.tsx
@@ -16,7 +16,13 @@ export const DialogHeader: FC<Partial<DialogHeaderProps>> = ({
   onClose
 }) => (
   <header className={classNames(css.header, className)}>
-    <h1 className={css.headerText}>{children}</h1>
+    <div>
+      {typeof children === 'string' ? (
+        <h1 className={css.headerText}>{children}</h1>
+      ) : (
+        children
+      )}
+    </div>
     {showCloseButton && (
       <button type="button" className={css.closeButton} onClick={onClose}>
         ✕

--- a/src/layers/Drawer/Drawer.module.css
+++ b/src/layers/Drawer/Drawer.module.css
@@ -14,9 +14,10 @@
   .header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding: 20px 30px;
 
-    > h1 {
+    .headerText {
       margin: 0;
       flex: 1;
     }

--- a/src/layers/Drawer/Drawer.story.tsx
+++ b/src/layers/Drawer/Drawer.story.tsx
@@ -21,13 +21,13 @@ export const Simple = () => {
   );
 };
 
-const CustomHeaderElement = () => <div>hello!</div>;
+const MyHeader = () => <div>hello!</div>;
 
-export const CustomHeader = () => {
+export const CustomHeaderElement = () => {
   const { toggleOpen, Drawer } = useDrawer();
   return (
     <Fragment>
-      <Drawer headerElement={<CustomHeaderElement />}>
+      <Drawer headerElement={<MyHeader />}>
         <p>Hello There!</p>
       </Drawer>
       <button type="button" onClick={toggleOpen}>
@@ -42,6 +42,20 @@ export const Header = () => {
   return (
     <Fragment>
       <Drawer header="Hello!!!!">
+        <p>Hello There!</p>
+      </Drawer>
+      <button type="button" onClick={toggleOpen}>
+        Open
+      </button>
+    </Fragment>
+  );
+};
+
+export const CustomHeader = () => {
+  const { toggleOpen, Drawer } = useDrawer();
+  return (
+    <Fragment>
+      <Drawer header={<h3>Hello!!!!</h3>}>
         <p>Hello There!</p>
       </Drawer>
       <button type="button" onClick={toggleOpen}>

--- a/src/layers/Drawer/DrawerHeader.tsx
+++ b/src/layers/Drawer/DrawerHeader.tsx
@@ -16,7 +16,13 @@ export const DrawerHeader: FC<Partial<DrawerHeaderProps>> = ({
   onClose
 }) => (
   <header className={classNames(css.header, className)}>
-    <h1>{children}</h1>
+    <div>
+      {typeof children === 'string' ? (
+        <h1 className={css.headerText}>{children}</h1>
+      ) : (
+        children
+      )}
+    </div>
     {showCloseButton && (
       <button type="button" className={css.closeButton} onClick={onClose}>
         ✕


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`header` props in both Dialog and Drawer accept more than just strings, but gets wrapped in an `<h1 />` tag which causes some styling issues unless you set a custom `headerElement` as well

Issue Number: N/A


## What is the new behavior?
Instead of having to set a custom `headerElement`, we can check if the header text that's passed in is a string or not, and if it's not, don't wrap it in the `<h1 />` tag

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
