### PR TITLE
Add support for default values in sort/getNextDirection 

### DIFF
--- a/src/data/Sort/utils.ts
+++ b/src/data/Sort/utils.ts
@@ -12,12 +12,23 @@ export interface SortValue {
   direction: SortDirection;
 }
 
-export function getNextDirection(direction?: SortDirection | null) {
+/**
+ * @param direction Current sort direction
+ *
+ * @param defaultDirection Inital sort direction in case currently unsorted
+ *
+ * @param canBeNull If next direction can be null (unsorted)
+ */
+export function getNextDirection(
+  direction?: SortDirection | null,
+  defaultDirection: NonNullable<SortDirection> = 'asc',
+  canBeNull: boolean = true
+) {
   if (!direction) {
-    return 'asc';
+    return defaultDirection;
   } else if (direction === 'asc') {
     return 'desc';
   } else if (direction === 'desc') {
-    return null;
+    return canBeNull ? null : 'asc';
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
This PR adds for support for default values in sort/getNextDirection and allows finer controls over sorting in case unsorted fields are not supported.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Provides finer control over sort
```

## What is the current behavior?
It cycles between asc->desc->null and the start value is always asc

## What is the new behavior?
- Start value of the cycle can be explicitly specified.
- It can cycle between just asc<->desc, leaving out null if the API does not support unsorted fields.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
