### PR TITLE
handle card header if react elements are passed in

### DIFF
--- a/src/layout/Card/Card.tsx
+++ b/src/layout/Card/Card.tsx
@@ -58,7 +58,11 @@ export const Card: FC<CardRefProps> = forwardRef(
     >
       {header && (
         <header className={classNames(css.header, headerClassName)}>
-          {header && <h3 className={css.headerText}>{header}</h3>}
+          {header && typeof header === 'string' ? (
+            <h3 className={css.headerText}>{header}</h3>
+          ) : (
+            header
+          )}
         </header>
       )}
       <div className={classNames(css.content, contentClassName)}>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
similar to how dialog header was, if a react element such as a custom header section tag was pass in instead of a string, it would get wrapped in the existing h3 tag

Issue Number: N/A


## What is the new behavior?
only string headers get wrapped in the existing `h3` tag, otherwise, the element gets dropped inside the `<header/>` tag instrad

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
