### PR TITLE
fix css typo

### DIFF
--- a/src/layout/Stack/Stack.module.css
+++ b/src/layout/Stack/Stack.module.css
@@ -20,7 +20,7 @@
   }
 
   &.startAlign {
-    itemsalign: flex-start;
+    align-items: flex-start;
   }
 
   &.endAlign {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
css typo making Stack option `alignItems="start"` not work
<img width="241" alt="image" src="https://github.com/reaviz/reablocks/assets/1513140/b8494655-40b0-44d2-9cef-886b332533a7">


Issue Number: N/A


## What is the new behavior?
`alignItems="start"` works as expected
<img width="242" alt="image" src="https://github.com/reaviz/reablocks/assets/1513140/302aa05c-bb75-46e8-8a92-b1f73b354517">


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
