### PR TITLE
update overriding `className` to be at the end of the classes list

### DIFF
--- a/src/data/Pager/Pager.tsx
+++ b/src/data/Pager/Pager.tsx
@@ -17,6 +17,11 @@ export interface PagerProps {
   className?: string;
 
   /**
+   * The class name to add to the page buttons.
+   */
+  pageClassName?: string;
+
+  /**
    * The current page number.
    */
   page: number;
@@ -59,6 +64,7 @@ export interface PagerProps {
 
 export const Pager: FC<PagerProps> = ({
   className,
+  pageClassName,
   page,
   size,
   total,
@@ -124,9 +130,13 @@ export const Pager: FC<PagerProps> = ({
               size="small"
               disabled={page === i}
               title={`Page ${i + 1}`}
-              className={classNames(css.page, {
-                [css.active]: page === i
-              })}
+              className={classNames(
+                css.page,
+                {
+                  [css.active]: page === i
+                },
+                pageClassName
+              )}
               onClick={() => onPageChange?.(i)}
             >
               {(i + 1).toLocaleString()}

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -70,14 +70,18 @@ export const Button: FC<ButtonProps & ButtonRef> = forwardRef(
       disabled={disabled}
       ref={ref}
       whileTap={{ scale: disabled || disableAnimation ? 1 : 0.9 }}
-      className={classNames(css.btn, className, {
-        [css.fullWidth]: fullWidth,
-        [css.disableMargins]: disableMargins,
-        [css.disablePadding]: disablePadding,
-        [css[color]]: true,
-        [css[size]]: true,
-        [css[variant]]: true
-      })}
+      className={classNames(
+        css.btn,
+        {
+          [css.fullWidth]: fullWidth,
+          [css.disableMargins]: disableMargins,
+          [css.disablePadding]: disablePadding,
+          [css[color]]: true,
+          [css[size]]: true,
+          [css[variant]]: true
+        },
+        className
+      )}
     >
       {children}
     </motion.button>

--- a/src/elements/Chip/Chip.tsx
+++ b/src/elements/Chip/Chip.tsx
@@ -78,15 +78,19 @@ export const Chip: FC<ChipProps & ChipRef> = forwardRef(
       ref={ref}
       tabIndex={onClick ? 0 : -1}
       onClick={onClick}
-      className={classNames(css.chip, className, {
-        [css[color]]: true,
-        [css[variant]]: true,
-        [css[size]]: true,
-        [css.selected]: !!selected,
-        [css.disabled]: disabled,
-        [css.selectable]: onClick && !disabled,
-        [css.disableMargins]: disableMargins
-      })}
+      className={classNames(
+        css.chip,
+        {
+          [css[color]]: true,
+          [css[variant]]: true,
+          [css[size]]: true,
+          [css.selected]: !!selected,
+          [css.disabled]: disabled,
+          [css.selectable]: onClick && !disabled,
+          [css.disableMargins]: disableMargins
+        },
+        className
+      )}
     >
       {start && <div className={css.startAdornment}>{start}</div>}
       <div className={css.content}>{children}</div>

--- a/src/form/Textarea/Textarea.tsx
+++ b/src/form/Textarea/Textarea.tsx
@@ -40,11 +40,15 @@ export const Textarea: FC<TextareaProps> = ({
 
   return (
     <div
-      className={classNames(css.root, containerClassName, {
-        [css.fullWidth]: fullWidth,
-        [css.error]: error,
-        [css[size]]: size
-      })}
+      className={classNames(
+        css.root,
+        {
+          [css.fullWidth]: fullWidth,
+          [css.error]: error,
+          [css[size]]: size
+        },
+        containerClassName
+      )}
     >
       <TextareaAutosize
         ref={inputRef}

--- a/src/form/Toggle/Toggle.tsx
+++ b/src/form/Toggle/Toggle.tsx
@@ -48,11 +48,15 @@ export const Toggle: FC<
       {...rest}
       ref={ref}
       tabIndex={0}
-      className={classnames(css.switch, className, {
-        [css.disabled]: disabled,
-        [css.checked]: checked,
-        [css[size]]: true
-      })}
+      className={classnames(
+        css.switch,
+        {
+          [css.disabled]: disabled,
+          [css.checked]: checked,
+          [css[size]]: true
+        },
+        className
+      )}
       onClick={() => {
         if (!disabled && onChange) {
           onChange(!checked);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Overriding `className` props aren't at the end of the list so often requires `!important` in the external code's css which isn't ideal.

## What is the new behavior?
I've moved (some - didn't go through all of it) of the places where the overriding `className` prop isn't at the end of the list to the end.

I've also added new className props to handle individual page styling for Pager component

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
