### PR TITLE
Add custom content classname to Drawer

### DIFF
--- a/src/layers/Drawer/Drawer.tsx
+++ b/src/layers/Drawer/Drawer.tsx
@@ -11,6 +11,7 @@ export interface DrawerProps extends Omit<GlobalOverlayProps, 'children'> {
   position?: 'start' | 'end' | 'top' | 'bottom';
   size?: string | number;
   className?: string;
+  contentClassName?: string;
   backdropClassName?: string;
   disablePadding?: boolean;
   header?: any;
@@ -21,6 +22,7 @@ export interface DrawerProps extends Omit<GlobalOverlayProps, 'children'> {
 
 export const Drawer: FC<Partial<DrawerProps>> = ({
   className,
+  contentClassName,
   headerElement,
   children,
   open,
@@ -101,7 +103,7 @@ export const Drawer: FC<Partial<DrawerProps>> = ({
                   ✕
                 </button>
               )}
-              <div className={css.content}>
+              <div className={classNames(css.content, contentClassName)}>
                 {typeof children === 'function' ? children() : children}
               </div>
             </motion.div>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently you cannot pass custom styling to the content layer of a `Drawer`

Issue Number: N/A


## What is the new behavior?
You can now pass a `contentClassName` to a `Drawer` to style the content layer

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
My specific use case for this is to make the content scrollable

![Screenshot 2023-10-19 at 1 13 45 PM](https://github.com/reaviz/reablocks/assets/40581813/c72c0114-0dea-49c3-8825-0fc34931710f)

