### PR TITLE
Add neutral icon to sort

### DIFF
--- a/src/data/Sort/Sort.story.tsx
+++ b/src/data/Sort/Sort.story.tsx
@@ -16,6 +16,53 @@ export const Simple = () => {
   );
 };
 
+export const CustomIcons = () => {
+  const [dir, setDir] = useState<SortDirection>('asc');
+  return (
+    <Sort
+      direction={dir}
+      onSort={setDir}
+      neutralIcon={({ className }) => (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="50"
+          height="50"
+          viewBox="0 0 16 16"
+          fill="none"
+          className={className}
+        >
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M8.35107 2.64425L7.99972 2.29724L7.64837 2.64425L4.94837 5.31092L4.59263 5.66227L5.29533 6.37376L5.65107 6.02241L7.49972 4.19658V6.5H7.49962V7L7.49962 11.8034L5.65097 9.97759L5.29523 9.62624L4.59253 10.3377L4.94827 10.6891L7.64827 13.3557L7.99962 13.7028L8.35097 13.3557L11.051 10.6891L11.4067 10.3377L10.704 9.62624L10.3483 9.97759L8.49962 11.8034L8.49962 9.5H8.49972V9V4.19658L10.3484 6.02241L10.7041 6.37376L11.4068 5.66227L11.0511 5.31092L8.35107 2.64425Z"
+            fill="#90919C"
+          />
+        </svg>
+      )}
+      neutralIconClassName={css.neutralIcon}
+      icon={({ className }) => (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="50"
+          height="50"
+          viewBox="0 0 16 16"
+          fill="none"
+          className={className}
+        >
+          <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M7.99989 13.2028L4.5928 9.83773L5.2955 9.12624L7.49989 11.3034L7.49989 3L8.49989 3L8.49989 11.3034L10.7043 9.12624L11.407 9.83773L7.99989 13.2028Z"
+            fill="#90919C"
+          />
+        </svg>
+      )}
+    >
+      Age
+    </Sort>
+  );
+};
+
 export const Disabled = () => {
   const [dir, setDir] = useState<SortDirection>('asc');
   return (

--- a/src/data/Sort/Sort.story.tsx
+++ b/src/data/Sort/Sort.story.tsx
@@ -39,7 +39,6 @@ export const CustomIcons = () => {
           />
         </svg>
       )}
-      neutralIconClassName={css.neutralIcon}
       icon={({ className }) => (
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/data/Sort/Sort.tsx
+++ b/src/data/Sort/Sort.tsx
@@ -35,6 +35,16 @@ export interface SortProps extends PropsWithChildren {
    * The icon to display
    */
   icon?: any;
+
+  /**
+   * The neutral icon to display.
+   */
+  neutralIcon?: (props: { className?: string }) => React.JSX.Element;
+
+  /**
+   * Additional css classnames to apply to the neutral icon.
+   */
+  neutralIconClassName?: string;
 }
 
 export const Sort: FC<SortProps> = ({
@@ -43,6 +53,8 @@ export const Sort: FC<SortProps> = ({
   direction,
   iconClassName,
   icon: Icon,
+  neutralIcon: NeutralIcon,
+  neutralIconClassName,
   children,
   onSort
 }) => {
@@ -96,6 +108,18 @@ export const Sort: FC<SortProps> = ({
           >
             <Icon
               className={classNames(css.icon, iconClassName, css.descIcon)}
+            />
+          </motion.div>
+        )}
+        {!!NeutralIcon && !direction && (
+          <motion.div
+            key="neutral"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10, transition: { duration: 0.05 } }}
+          >
+            <NeutralIcon
+              className={classNames(css.icon, neutralIconClassName)}
             />
           </motion.div>
         )}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no option to add a neutral icon for a `Sort` component that has no direction

Issue Number: N/A


## What is the new behavior?
I added a prop `neutralIcon` to the `Sort` component to display while there's no sorting `direction`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

https://github.com/reaviz/reablocks/assets/40581813/d5646518-ef85-474d-98c3-e70114a83f8d


