### PR TITLE
Allow custom scales and decimals to be set for DataSize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reablocks",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reablocks",
-      "version": "5.5.1",
+      "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@reaviz/react-use-fuzzy": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15429,9 +15429,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -30840,9 +30840,9 @@
       "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",

--- a/src/data/DataSize/DataSize.story.tsx
+++ b/src/data/DataSize/DataSize.story.tsx
@@ -17,6 +17,47 @@ export const Simple = () => (
     <DataSize value="434334434123" />
     <br />
     <DataSize value={324344535345232} />
+    <br />
+    <DataSize value={324344535345232482} />
+    <br />
+    <DataSize value={324344535345232482281} />
+    <br />
+    <DataSize value={32434453534523248228135} />
+    <br />
+    <DataSize value={32434453534523248228123412} />
+  </Fragment>
+);
+
+export const CustomScale = () => {
+  const scale = ['b', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb', 'yb'];
+  return (
+    <Fragment>
+      <DataSize value="99" scale={scale} />
+      <br />
+      <DataSize value="4500" scale={scale} />
+      <br />
+      <DataSize value="34343233" scale={scale} />
+      <br />
+      <DataSize value="434334434123" scale={scale} />
+      <br />
+      <DataSize value={324344535345232} scale={scale} />
+      <br />
+      <DataSize value={324344535345232482} scale={scale} />
+      <br />
+      <DataSize value={324344535345232482281} scale={scale} />
+      <br />
+      <DataSize value={32434453534523248228135} scale={scale} />
+      <br />
+      <DataSize value={32434453534523248228123412} scale={scale} />
+    </Fragment>
+  );
+};
+
+export const CustomDecimals = () => (
+  <Fragment>
+    <DataSize value={34343233} decimals={0} />
+    <br />
+    <DataSize value={34343233} decimals={5} />
   </Fragment>
 );
 

--- a/src/data/DataSize/DataSize.tsx
+++ b/src/data/DataSize/DataSize.tsx
@@ -11,8 +11,21 @@ export interface DataSizeProps {
    * If the value is undefined/null it will return this value.
    */
   emptyValue?: string;
+
+  /**
+   * Customize scale for displaying units.
+   */
+  scale?: string[];
+
+  /**
+   * The number of decimals to be set.
+   */
+  decimals?: number;
 }
 
-export const DataSize: FC<DataSizeProps> = ({ value, emptyValue }) => (
-  <>{formatSize(value, emptyValue)}</>
-);
+export const DataSize: FC<DataSizeProps> = ({
+  value,
+  emptyValue,
+  scale,
+  decimals
+}) => <>{formatSize(value, emptyValue, scale, decimals)}</>;

--- a/src/data/DataSize/utils.ts
+++ b/src/data/DataSize/utils.ts
@@ -2,8 +2,14 @@ import humanFormat from 'human-format';
 
 export type FormatSizeTypes = number | string | null | undefined;
 
-export function formatSize(size: FormatSizeTypes, emptyValue = 'N/A') {
+export function formatSize(
+  size: FormatSizeTypes,
+  emptyValue = 'N/A',
+  scale = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'],
+  decimals = 2
+) {
   let newSize = size;
+  var binaryScale = humanFormat.Scale.create(scale, 1024);
 
   if (typeof size === 'string') {
     newSize = parseFloat(size as string);
@@ -11,5 +17,8 @@ export function formatSize(size: FormatSizeTypes, emptyValue = 'N/A') {
     return [emptyValue];
   }
 
-  return humanFormat.bytes(newSize as number);
+  return humanFormat(newSize as number, {
+    scale: binaryScale,
+    decimals
+  });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
DataSize `unit` and number of decimal places are set and cannot be configured by the user

Issue Number: N/A


## What is the new behavior?
Allows custom `scale` and `decimal` to be passed into the component 

![image](https://github.com/reaviz/reablocks/assets/1513140/51378222-3d7f-4159-970a-bbcd9f57edf3)

![image](https://github.com/reaviz/reablocks/assets/1513140/57d9dc1b-8065-4880-9edd-225b87d515f2)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
