### PR TITLE
remove select toggle menu button from tabbing order

### DIFF
--- a/src/form/Select/SelectInput/SelectInput.module.css
+++ b/src/form/Select/SelectInput/SelectInput.module.css
@@ -127,6 +127,11 @@
       border: none;
       background: none;
 
+      &:focus-visible {
+        outline: 1px dashed var(--button-focus);
+        outline-offset: var(--button-focus-offset);
+      }
+
       &:not([disabled]) {
         cursor: pointer;
       }

--- a/src/form/Select/SelectInput/SelectInput.tsx
+++ b/src/form/Select/SelectInput/SelectInput.tsx
@@ -379,6 +379,7 @@ export const SelectInput: FC<Partial<SelectInputProps>> = ({
             disabled={disabled}
             className={classNames(css.expand, css.btn, 'select-input-toggle')}
             onClick={onExpandClick}
+            tabIndex={-1}
           >
             {expandIcon}
           </button>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The toggle menu button on the `<Select/>` component was in the tabbing order which caused a redundancy since the user would tab to the input, the dropdown would open (if there was one) and then tab again and it would focus the button instead of moving to the next input in the order. Also noting here that if the user did toggle the button open, the menu would not be in focus to interact with. This fix solves both issues.

https://github.com/reaviz/reablocks/assets/1513140/71533b10-f1df-4338-a6f0-e3bef59849c7



Issue Number: N/A


## What is the new behavior?
This changes adds `tabIndex={-1}` to only the toggle menu button to remove it from the tabbing order and skipping it when you tab through a form

https://github.com/reaviz/reablocks/assets/1513140/9310699b-3eda-4caa-8bd2-c1658a865540



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
