### PR TITLE
fix adornment fill variable never being used

### DIFF
--- a/src/form/Input/Input.module.css
+++ b/src/form/Input/Input.module.css
@@ -6,7 +6,9 @@
   flex-direction: row;
   align-items: center;
   flex-wrap: nowrap;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition:
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
   box-sizing: border-box;
 
   &.small {
@@ -46,6 +48,7 @@
     svg {
       width: var(--input-adornment-size);
       height: var(--input-adornment-size);
+      fill: var(--input-adornment-fill);
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`--input-adornment-fill` variable was defined in the theme file, but never used

Issue Number: N/A


## What is the new behavior?
added the use of `--input-adornment-fill` in the input css file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
