### PR TITLE
Fix Range dragging

### DIFF
--- a/src/form/Range/RangeSingle.tsx
+++ b/src/form/Range/RangeSingle.tsx
@@ -46,7 +46,7 @@ export const RangeSingle: FC<RangeProps<number>> = ({
 
   useEffect(() => {
     setRangeWidth(range.current.offsetWidth);
-    setRangeLeft(range.current.offsetLeft);
+    setRangeLeft(range.current?.getBoundingClientRect()?.left || 0);
     valueX.set(getPosition(currentValue));
   }, [range, currentValue, valueX, getPosition]);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you place RangeSingle in a parent element with some affected positioning the drag gets messed up


## What is the new behavior?
You can place RangeSingle in any parent element


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This sets the range left offset relative to the viewport instead of the parent element

It needs to be based off viewport to align with the pointer clientX being used to calc the handle position

This _shouldn't_ be a breaking change, but it feels like it could depending if people have done some hacky solutions to avoid this problem

BEFORE

https://github.com/reaviz/reablocks/assets/40581813/61e5707d-da0d-477d-b9ac-ee5ac4cf44fe


AFTER

https://github.com/reaviz/reablocks/assets/40581813/65e0d9fa-0b5f-4c3b-a52b-7f8c293b4c39

Also story still works as expected without added div wrapper

https://github.com/reaviz/reablocks/assets/40581813/4695a7b8-b120-4f42-bfb2-1e3ae70771f2



