### PR TITLE
Select: support for default filter

### DIFF
--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -71,6 +71,11 @@ export interface SelectProps {
   value?: string | string[];
 
   /**
+   * The deafult value of the input filter.
+   */
+  defaultFilterValue?: string;
+
+  /**
    * Whether the select is required or not.
    */
   required?: boolean;
@@ -209,6 +214,7 @@ export const Select: FC<Partial<SelectProps>> = ({
   activeClassName,
   children,
   value,
+  defaultFilterValue,
   required,
   input,
   menu,
@@ -260,6 +266,14 @@ export const Select: FC<Partial<SelectProps>> = ({
       }
     }
   }, [keyword, index, setIndex, result]);
+
+  useEffect(() => {
+    // Run only on initial render
+    if (!value && defaultFilterValue) {
+      search(defaultFilterValue);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const groups = useMemo(() => getGroups(result), [result]);
 

--- a/src/form/Select/SingleSelect.story.tsx
+++ b/src/form/Select/SingleSelect.story.tsx
@@ -557,3 +557,24 @@ export const TabToSelect = () => {
     </div>
   );
 };
+
+export const DefaultFilter = () => {
+  const [value, setValue] = useState<string | null>(null);
+  return (
+    <div style={{ width: 300 }}>
+      <Select
+        placeholder="Select a category..."
+        value={value}
+        onChange={v => {
+          setValue(v);
+          console.log('onChange', v);
+        }}
+        defaultFilterValue="twi"
+      >
+        <SelectOption value="facebook">facebook</SelectOption>
+        <SelectOption value="twitter">twitter</SelectOption>
+        <SelectOption value="twitch">twitch</SelectOption>
+      </Select>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR adds support for a `defaultFilterValue` prop in the Select component.
Currently, while we have a `onInputChange` callback but there's no way so specify the initial filter value.

https://github.com/reaviz/reablocks/assets/33908100/81f0626a-37df-4cb8-abb0-8e5c02bb450d

