### PR TITLE
added primary and secondary color types

### DIFF
--- a/src/utils/Theme/types.ts
+++ b/src/utils/Theme/types.ts
@@ -68,6 +68,8 @@ export interface Colors {
   pink?: Color;
   slate?: Color;
   overlay?: Color;
+  primary?: Color;
+  secondary?: Color;
 }
 
 export interface FontFamilies {


### PR DESCRIPTION
This PR add the `primary` and `secondary` properties to the `Colors` interface so we can define different scale values for them. This wouldn't be possible in the `Palletes` interface where we could define just a single value.