### PR TITLE
Add interactive Popover hover state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reablocks",
-  "version": "5.8.2",
+  "version": "5.8.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reablocks",
-      "version": "5.8.2",
+      "version": "5.8.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@marko19907/string-to-color": "^1.0.0",

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -207,10 +207,14 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
         return (
           <motion.div
             onMouseOver={() => {
-              clearTimeout(timeout.current);
+              if (!isPopover) {
+                clearTimeout(timeout.current);
+              }
             }}
             onMouseLeave={() => {
-              handleClose();
+              if (!isPopover) {
+                handleClose();
+              }
             }}
             className={classNames(css.tooltip, className)}
             initial={{

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useState, useRef, useEffect, ReactNode } from 'react';
+import React, {
+  FC,
+  useState,
+  useRef,
+  useEffect,
+  ReactNode,
+  useCallback
+} from 'react';
 import classNames from 'classnames';
 import {
   Placement,
@@ -92,7 +99,7 @@ export interface TooltipProps {
   followCursor?: boolean;
 
   /**
-   * Add pointer events or not. Usually not for tooltips.
+   * Add pointer events or not.
    */
   pointerEvents?: string;
 
@@ -152,6 +159,14 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
     }
   );
 
+  const handleClose = useCallback(() => {
+    clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => {
+      deactivateTooltip(ref.current, isPopover);
+      onClose?.();
+    }, leaveDelay);
+  }, [deactivateTooltip, isPopover, onClose, leaveDelay]);
+
   useEffect(() => {
     // componentDidUpdateLogic style logic
     if (!mounted.current) {
@@ -191,6 +206,12 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
 
         return (
           <motion.div
+            onMouseOver={() => {
+              clearTimeout(timeout.current);
+            }}
+            onMouseLeave={() => {
+              handleClose();
+            }}
             className={classNames(css.tooltip, className)}
             initial={{
               opacity: 0,
@@ -218,8 +239,8 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
         );
       }}
       onOpen={() => {
+        clearTimeout(timeout.current);
         if (!internalVisible) {
-          clearTimeout(timeout.current);
           timeout.current = setTimeout(() => {
             if (!disabled) {
               deactivateAllTooltips(isPopover);
@@ -235,11 +256,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
           e?.nativeEvent?.type !== 'click' ||
           (e?.nativeEvent?.type === 'click' && closeOnClick)
         ) {
-          clearTimeout(timeout.current);
-          timeout.current = setTimeout(() => {
-            deactivateTooltip(ref.current, isPopover);
-            onClose?.();
-          }, leaveDelay);
+          handleClose();
         }
       }}
     >

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -208,12 +208,20 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
           <motion.div
             onMouseOver={() => {
               // keep popover open when interacting with it
-              if (isPopover && trigger === 'hover') {
+              if (
+                isPopover &&
+                (trigger === 'hover' ||
+                  (Array.isArray(trigger) && trigger.includes('hover')))
+              ) {
                 clearTimeout(timeout.current);
               }
             }}
             onMouseLeave={() => {
-              if (isPopover && trigger === 'hover') {
+              if (
+                isPopover &&
+                (trigger === 'hover' ||
+                  (Array.isArray(trigger) && trigger.includes('hover')))
+              ) {
                 handleClose();
               }
             }}

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -99,7 +99,7 @@ export interface TooltipProps {
   followCursor?: boolean;
 
   /**
-   * Add pointer events or not.
+   * Add pointer events or not. Usually not for tooltips.
    */
   pointerEvents?: string;
 
@@ -207,12 +207,13 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
         return (
           <motion.div
             onMouseOver={() => {
-              if (!isPopover) {
+              // keep popover open when interacting with it
+              if (isPopover && trigger === 'hover') {
                 clearTimeout(timeout.current);
               }
             }}
             onMouseLeave={() => {
-              if (!isPopover) {
+              if (isPopover && trigger === 'hover') {
                 handleClose();
               }
             }}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Popovers disappear when you hover over them/try to interact with their content while using a `hover` trigger. There's no options to enable this kinda behavior


## What is the new behavior?
Popover's stay visible while they're hovered when using `hover` trigger

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


https://github.com/reaviz/reablocks/assets/40581813/95dbaa6c-26c3-44e1-b275-041320e2bc1d



