### PR TITLE
Avoid recreate notify method on notifications list update

### DIFF
--- a/src/layers/Notification/Notifications.tsx
+++ b/src/layers/Notification/Notifications.tsx
@@ -58,40 +58,35 @@ export const Notifications: FC<NotificationsProps> = ({
 
   const notify = useCallback(
     (title: string, options: NotificationOptions = {}) => {
-      // If we are flooded with the same message over and over,
-      // dont add more of the same type. Mainly used for error use cases.
-      if (preventFlooding) {
-        const has = notifications.find(n => n.title === title);
-
-        if (has) {
-          return false;
+      setNotifications(notifications => {
+        // If we are flooded with the same message over and over,
+        // don't add more of the same type. Mainly used for error use cases.
+        if (preventFlooding && notifications.find(n => n.title === title)) {
+          return notifications;
         }
-      }
 
-      const id = nextId++;
+        const id = nextId++;
 
-      const obj = {
-        title,
-        id,
-        variant: 'default',
-        timeout,
-        showClose,
-        ...options
-      };
+        const obj = {
+          title,
+          id,
+          variant: 'default',
+          timeout,
+          showClose,
+          ...options
+        };
 
-      const sorted = [obj, ...notifications];
+        const sorted = [obj, ...notifications];
 
-      // Clear old notifications if we hit limit
-      if (sorted.length > limit) {
-        sorted.pop();
-      }
+        // Clear old notifications if we hit limit
+        if (sorted.length > limit) {
+          sorted.pop();
+        }
 
-      // Update the container instance
-      setNotifications(sorted);
-
-      return id;
+        return sorted;
+      });
     },
-    [limit, notifications, preventFlooding, showClose, timeout]
+    [limit, preventFlooding, showClose, timeout]
   );
 
   const notifyError = useCallback(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Every time when notifications list is updated - notify method updates as well, what is involve unnecessary render triggers


## What is the new behavior?
Get notifications list from setNotifications callback to avoid notifications dependency for notify callback


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
