### PR TITLE
add a11y support for clickable list items

### DIFF
--- a/src/layers/Menu/Menu.story.tsx
+++ b/src/layers/Menu/Menu.story.tsx
@@ -186,6 +186,37 @@ export const Simple = () => {
   );
 };
 
+export const Selectable = () => {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef(null);
+
+  return (
+    <>
+      <button type="button" ref={buttonRef} onClick={() => setOpen(!open)}>
+        Open
+      </button>
+      <Menu open={open} onClose={() => setOpen(false)} reference={buttonRef}>
+        <Card disablePadding>
+          <List>
+            <ListItem start={<Icon />} onClick={() => console.log('1')}>
+              Menu Item 1
+            </ListItem>
+            <ListItem start={<Icon />} onClick={() => console.log('2')}>
+              Menu Item 2
+            </ListItem>
+            <ListItem start={<Icon />} onClick={() => console.log('3')}>
+              Menu Item 3
+            </ListItem>
+            <ListItem start={<Icon />} onClick={() => console.log('4')}>
+              Menu Item 4
+            </ListItem>
+          </List>
+        </Card>
+      </Menu>
+    </>
+  );
+};
+
 const Icon = () => (
   <svg
     width="16"

--- a/src/layout/List/ListItem/ListItem.tsx
+++ b/src/layout/List/ListItem/ListItem.tsx
@@ -59,7 +59,8 @@ export const ListItem = forwardRef<HTMLDivElement, ListItemProps>(
     <div
       {...rest}
       ref={ref}
-      role="listitem"
+      role={onClick ? 'button' : 'listitem'}
+      tabIndex={onClick ? 0 : undefined}
       onClick={e => !disabled && onClick?.(e)}
       className={classNames(className, css.listItem, {
         [css.disabled]: disabled,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
list items that are clickable are not keyboard navigable

Issue Number: N/A


## What is the new behavior?
adds `role=button` and `tabIndex=0` when `<ListItem />` component has `onClick` attribute


https://github.com/reaviz/reablocks/assets/1513140/c9f67607-6065-47ff-8a77-de32d9adb244



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
