### PR TITLE
Add ability to define theme for components

### DIFF
--- a/docs/theme/Theme.mdx
+++ b/docs/theme/Theme.mdx
@@ -3,14 +3,14 @@ import { Meta } from '@storybook/addon-docs';
 <Meta title="Docs/Theme/Getting Started" />
 
 # Getting Started
-Reablocks theming is seamlessly integrated into the Tailwind CSS configuration, allowing for a highly customizable design system. 
-This approach leverages Tailwind's utility-first CSS to offer you an extensive range of design tokens such as colors, border radii, shadows, and font sizes. 
+Reablocks theming is seamlessly integrated into the Tailwind CSS configuration, allowing for a highly customizable design system.
+This approach leverages Tailwind's utility-first CSS to offer you an extensive range of design tokens such as colors, border radii, shadows, and font sizes.
 In addition, Reablocks provides a set of pre-defined [Storybook blocks](?path=/docs/docs-theme-blocks--docs) that can be used to quickly build and customize your UI components in a Storybook environment.
 
 &nbsp;
 
 ### Integrating Reablocks Theme in Your Application
-To get started with Reablocks theming, you first need to incorporate the `ThemeProvider` into the root of your application. 
+To get started with Reablocks theming, you first need to incorporate the `ThemeProvider` into the root of your application.
 This provider applies the selected theme across all your components, ensuring a consistent look and feel.
 
 - **Basic Theme Example**
@@ -24,13 +24,33 @@ export const App = () => (
   </ThemeProvider>
 );
 ```
-**Result:** In this example, the `darkTheme` from Reablocks is applied to your application. 
+**Result:** In this example, the `darkTheme` from Reablocks is applied to your application.
 Simply wrap your component hierarchy with the `ThemeProvider`, and the theme is automatically applied.
+
+### Create a reusable component with a custom theme
+You can also pass theme={} directly to any component, which will override the theme for that component, but not its children.
+This is useful if you want to create a reusable component with a custom theme.
+
+```tsx
+import { darkTooltipTheme, TooltipTheme, extendComponentTheme } from 'reablocks';
+
+export const CustomTheme = () => {
+  const customTheme = extendComponentTheme<TooltipTheme>(darkTooltipTheme, {
+    base: 'rounded bg-green-800 text-white font-bold p-3 text-base'
+  });
+
+  return (
+    <div>
+      <Tooltip theme={customTheme} content="Hi there">Hover me</Tooltip>
+    </div>
+  );
+};
+```
 
 &nbsp;
 
 ### Extending the Reablocks Theme
-Reablocks allows you to extend its themes to customize according to your design requirements. 
+Reablocks allows you to extend its themes to customize according to your design requirements.
 You can modify existing styles or add new ones to fit your application's unique design language.
 
 - **Customizing Theme Example**
@@ -62,13 +82,13 @@ export const App = () => (
   </ThemeProvider>
 );
 ```
-**Result:** This example demonstrates how to create a `customTheme` that extends the `darkTheme`. 
+**Result:** This example demonstrates how to create a `customTheme` that extends the `darkTheme`.
 By using the `extendTheme` function, you can merge your customizations with the base theme, resulting in a coherent design system that still benefits from Reablocks' foundation.
 
 &nbsp;
 
 ### Defining Custom Tokens with TailwindCSS
-Reablocks themes can further leverage TailwindCSS's configuration to define custom design tokens. 
+Reablocks themes can further leverage TailwindCSS's configuration to define custom design tokens.
 This allows for an even deeper level of customization, integrating seamlessly with your TailwindCSS setup.
 
 - **TailwindCSS Configuration Example**
@@ -106,5 +126,5 @@ const config: Config = {
 export default config;
 
 ```
-**Result:** In this configuration, we extend the default TailwindCSS theme to include custom colors for primary and secondary palettes. 
+**Result:** In this configuration, we extend the default TailwindCSS theme to include custom colors for primary and secondary palettes.
 The `extend` property allows you to add to the existing design tokens without overriding them, ensuring you can update and maintain your theme easily.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reablocks",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reablocks",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@marko19907/string-to-color": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reablocks",
-  "version": "6.0.0-alpha.8",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reablocks",
-      "version": "6.0.0-alpha.8",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@marko19907/string-to-color": "^1.0.0",

--- a/src/data/DateFormat/DateFormat.tsx
+++ b/src/data/DateFormat/DateFormat.tsx
@@ -57,6 +57,11 @@ export interface DateFormatProps {
    * The message to display when the date is empty. Default is "N/A".
    */
   emptyMessage?: string;
+
+  /**
+   * Theme for the DateFormat.
+   */
+  theme?: DateFormatTheme;
 }
 
 export const DateFormat: FC<DateFormatProps> = ({
@@ -68,7 +73,8 @@ export const DateFormat: FC<DateFormatProps> = ({
   includeSeconds,
   addSuffix,
   fromNow,
-  date
+  date,
+  theme: customTheme
 }) => {
   const [cache, setCache] = useState<string | null>(
     window.localStorage.getItem(`DATES_${cacheKey}`) || null
@@ -134,7 +140,7 @@ export const DateFormat: FC<DateFormatProps> = ({
     return () => clearTimeout(cur);
   });
 
-  const theme: DateFormatTheme = useComponentTheme('dateFormat');
+  const theme: DateFormatTheme = useComponentTheme('dateFormat', customTheme);
 
   if (!date) {
     return <>{emptyMessage}</>;

--- a/src/data/Ellipsis/Ellipsis.tsx
+++ b/src/data/Ellipsis/Ellipsis.tsx
@@ -33,6 +33,11 @@ export interface EllipsisProps {
    * Class name for the container.
    */
   className?: string;
+
+  /**
+   * Theme for the Ellipsis.
+   */
+  theme?: EllipsisTheme;
 }
 
 export const Ellipsis: FC<EllipsisProps> = ({
@@ -41,7 +46,8 @@ export const Ellipsis: FC<EllipsisProps> = ({
   title,
   removeLinebreaks,
   expandable,
-  limit
+  limit,
+  theme: customTheme
 }) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
@@ -52,7 +58,7 @@ export const Ellipsis: FC<EllipsisProps> = ({
     return ellipsize(formatted, limit, { ellipse: expandable ? '' : '...' });
   }, [expandable, limit, value, removeLinebreaks]);
 
-  const theme: EllipsisTheme = useComponentTheme('ellipsis');
+  const theme: EllipsisTheme = useComponentTheme('ellipsis', customTheme);
 
   return (
     <span className={className}>

--- a/src/data/Pager/Pager.tsx
+++ b/src/data/Pager/Pager.tsx
@@ -10,6 +10,7 @@ import StartArrow from './assets/arrow-start.svg?react';
 import { FUZZY_RANGE, getItemsRange, getPageRange } from './utils';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { PagerTheme } from './PagerTheme';
 
 export interface PagerProps {
   /**
@@ -76,6 +77,11 @@ export interface PagerProps {
    * The type of table data for the pager to display.
    */
   displayMode?: 'pages' | 'items' | 'all';
+
+  /**
+   * The theme for the Pager.
+   */
+  theme?: PagerTheme;
 }
 
 export const Pager: FC<PagerProps> = ({
@@ -91,14 +97,15 @@ export const Pager: FC<PagerProps> = ({
   previousArrow,
   nextArrow,
   onPageChange,
-  displayMode
+  displayMode,
+  theme: customTheme
 }) => {
   const pageCount = Math.ceil(total / size);
   const canPrevious = page !== 0;
   const canNext = page < pageCount - 1;
   const [startPage, endPage] = getPageRange(page, pageCount - 1);
   const [startItem, endItem] = getItemsRange(page, size, total);
-  const theme = useComponentTheme('pager');
+  const theme = useComponentTheme('pager', customTheme);
 
   const previousPage = useCallback(() => {
     if (canPrevious) {

--- a/src/data/Redact/Redact.tsx
+++ b/src/data/Redact/Redact.tsx
@@ -34,6 +34,11 @@ export interface RedactProps {
    * Value to conceal.
    */
   value?: string;
+
+  /**
+   * The theme for the Redact.
+   */
+  theme?: RedactTheme;
 }
 
 export const Redact: FC<RedactProps> = ({
@@ -42,7 +47,8 @@ export const Redact: FC<RedactProps> = ({
   tooltipText,
   className,
   character,
-  value
+  value,
+  theme: customTheme
 }) => {
   const [visible, setVisible] = useState<boolean>(false);
   const masked = useMemo(
@@ -56,7 +62,7 @@ export const Redact: FC<RedactProps> = ({
     [value, character, compactLength]
   );
 
-  const theme: RedactTheme = useComponentTheme('redact');
+  const theme: RedactTheme = useComponentTheme('redact', customTheme);
 
   return (
     <span

--- a/src/data/Sort/Sort.tsx
+++ b/src/data/Sort/Sort.tsx
@@ -46,6 +46,11 @@ export interface SortProps extends PropsWithChildren {
    * Additional css classnames to apply to the neutral icon.
    */
   neutralIconClassName?: string;
+
+  /**
+   * Theme for the Sort.
+   */
+  theme?: SortTheme;
 }
 
 export const Sort: FC<SortProps> = ({
@@ -57,7 +62,8 @@ export const Sort: FC<SortProps> = ({
   neutralIcon: NeutralIcon,
   neutralIconClassName,
   children,
-  onSort
+  onSort,
+  theme: customTheme
 }) => {
   const onSortClick = useCallback(() => {
     if (!disabled) {
@@ -74,7 +80,7 @@ export const Sort: FC<SortProps> = ({
     [disabled, direction, onSort]
   );
 
-  const theme: SortTheme = useComponentTheme('sort');
+  const theme: SortTheme = useComponentTheme('sort', customTheme);
 
   return (
     <div

--- a/src/elements/Arrow/Arrow.tsx
+++ b/src/elements/Arrow/Arrow.tsx
@@ -13,10 +13,19 @@ export interface ArrowProps {
    * The direction of the arrow
    */
   direction?: 'up' | 'right' | 'down' | 'left';
+
+  /**
+   * Theme for the Arrow.
+   */
+  theme?: ArrowTheme;
 }
 
-export const Arrow: FC<ArrowProps> = ({ direction = 'down', className }) => {
-  const theme: ArrowTheme = useComponentTheme('arrow');
+export const Arrow: FC<ArrowProps> = ({
+  direction = 'down',
+  className,
+  theme: customTheme
+}) => {
+  const theme: ArrowTheme = useComponentTheme('arrow', customTheme);
 
   return (
     <svg

--- a/src/elements/Avatar/Avatar.tsx
+++ b/src/elements/Avatar/Avatar.tsx
@@ -39,11 +39,26 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
     lightness: number;
     alpha: number;
   };
+
+  /**
+   * Theme for the Avatar.
+   */
+  theme?: AvatarTheme;
 }
 
 export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
   (
-    { name, src, color, size, rounded, className, colorOptions, ...rest },
+    {
+      name,
+      src,
+      color,
+      size,
+      rounded,
+      className,
+      colorOptions,
+      theme: customTheme,
+      ...rest
+    },
     ref
   ) => {
     const fontSize = size * 0.4;
@@ -62,7 +77,7 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       return generateColor(name || '', colorOptions);
     }, [color, name, src, colorOptions]);
 
-    const theme: AvatarTheme = useComponentTheme('avatar');
+    const theme: AvatarTheme = useComponentTheme('avatar', customTheme);
 
     return (
       <div

--- a/src/elements/AvatarGroup/AvatarGroup.tsx
+++ b/src/elements/AvatarGroup/AvatarGroup.tsx
@@ -19,11 +19,22 @@ export interface AvatarGroupProps extends React.HTMLAttributes<HTMLDivElement> {
    * The maximum number of avatars to show before +x more
    */
   size?: number;
+
+  /**
+   * Theme for the AvatarGroup
+   */
+  theme?: AvatarGroupTheme;
 }
 
 export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
   (
-    { children, className, size, ...rest }: AvatarGroupProps,
+    {
+      children,
+      className,
+      size,
+      theme: customTheme,
+      ...rest
+    }: AvatarGroupProps,
     ref: Ref<HTMLDivElement>
   ) => {
     const childrenArray = Children.toArray(children);
@@ -33,7 +44,10 @@ export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
       size
     });
 
-    const theme: AvatarGroupTheme = useComponentTheme('avatarGroup');
+    const theme: AvatarGroupTheme = useComponentTheme(
+      'avatarGroup',
+      customTheme
+    );
 
     return (
       <div {...rest} ref={ref} className={twMerge(theme.base, className)}>

--- a/src/elements/Badge/Badge.tsx
+++ b/src/elements/Badge/Badge.tsx
@@ -23,6 +23,11 @@ export interface BadgeProps
   hidden?: boolean;
 
   placement?: BadgePlacement;
+
+  /**
+   * Theme for the Budge.
+   */
+  theme?: BadgeTheme;
 }
 
 export interface BadgeRef {
@@ -39,11 +44,12 @@ export const Badge: FC<BadgeProps & BadgeRef> = forwardRef(
       content,
       hidden,
       placement,
+      theme: customTheme,
       ...rest
     }: BadgeProps,
     ref
   ) => {
-    const theme: BadgeTheme = useComponentTheme('badge');
+    const theme: BadgeTheme = useComponentTheme('badge', customTheme);
 
     return (
       <span

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { ButtonGroupContext } from './ButtonGroupContext';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { ButtonTheme } from './ButtonTheme';
 
 export interface ButtonProps
   extends Omit<
@@ -53,6 +54,11 @@ export interface ButtonProps
    * Element to display after the Button content.
    */
   endAdornment?: any;
+
+  /**
+   * Theme for the Button.
+   */
+  theme?: ButtonTheme;
 }
 
 export interface ButtonRef {
@@ -74,11 +80,12 @@ export const Button: FC<ButtonProps & ButtonRef> = forwardRef(
       disabled,
       startAdornment,
       endAdornment,
+      theme: customTheme,
       ...rest
     }: ButtonProps,
     ref
   ) => {
-    const theme = useComponentTheme('button');
+    const theme = useComponentTheme('button', customTheme);
 
     const { variant: groupVariant, size: groupSize } =
       useContext(ButtonGroupContext);

--- a/src/elements/Chip/Chip.tsx
+++ b/src/elements/Chip/Chip.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef, ReactElement } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { ChipTheme } from './ChipTheme';
 
 export interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -49,6 +50,11 @@ export interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
    * Content to display before the chip label.
    */
   end?: ReactElement | string;
+
+  /**
+   * Theme for the Chip.
+   */
+  theme?: ChipTheme;
 }
 
 export interface ChipRef {
@@ -69,11 +75,12 @@ export const Chip: FC<ChipProps & ChipRef> = forwardRef(
       start,
       end,
       onClick,
+      theme: customTheme,
       ...rest
     },
     ref
   ) => {
-    const theme = useComponentTheme('chip');
+    const theme = useComponentTheme('chip', customTheme);
 
     return (
       <div

--- a/src/elements/Chip/DeletableChip.tsx
+++ b/src/elements/Chip/DeletableChip.tsx
@@ -16,11 +16,28 @@ export interface DeletableChipProps extends Omit<ChipProps, 'end'> {
    * Callback if the chip is deletable.
    */
   onDelete?: () => void;
+
+  /**
+   * Theme for the Deletable Chip.
+   */
+  theme?: ChipTheme;
 }
 
 export const DeletableChip: FC<DeletableChipProps & ChipRef> = forwardRef(
-  ({ children, disabled, deleteIcon, onDelete, size, color, ...rest }, ref) => {
-    const theme: ChipTheme = useComponentTheme('chip');
+  (
+    {
+      children,
+      disabled,
+      deleteIcon,
+      onDelete,
+      size,
+      color,
+      theme: customTheme,
+      ...rest
+    },
+    ref
+  ) => {
+    const theme: ChipTheme = useComponentTheme('chip', customTheme);
 
     return (
       <Chip

--- a/src/elements/CommandPalette/CommandPalette.tsx
+++ b/src/elements/CommandPalette/CommandPalette.tsx
@@ -65,6 +65,11 @@ export interface CommandPaletteProps extends PropsWithChildren {
    * When a hotkey was triggered.
    */
   onHotkey?: (hotkey: HotkeyIem) => void;
+
+  /**
+   * Theme for the CommandPalette.
+   */
+  theme?: CommandPaletteTheme;
 }
 
 export const CommandPalette: FC<CommandPaletteProps> = ({
@@ -76,7 +81,8 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
   emptyMessage,
   onHotkey,
   onSelectedIndexChange,
-  onSearchChange
+  onSearchChange,
+  theme: customTheme
 }) => {
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [filterText, setFilterText] = useState<string>(search);
@@ -107,7 +113,10 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
     }
   }, [selectedIndex, flattenedTree]);
 
-  const theme: CommandPaletteTheme = useComponentTheme('commandPalette');
+  const theme: CommandPaletteTheme = useComponentTheme(
+    'commandPalette',
+    customTheme
+  );
 
   return (
     <Card className={theme.base} disablePadding ref={elementRef}>

--- a/src/elements/CommandPalette/CommandPaletteInput/CommandPaletteInput.tsx
+++ b/src/elements/CommandPalette/CommandPaletteInput/CommandPaletteInput.tsx
@@ -12,6 +12,7 @@ import { HotkeyIem } from '../useFlattenedTree';
 import Mousetrap from 'mousetrap';
 import { CommandPaletteTheme } from '../CommandPaletteTheme';
 import { useComponentTheme } from '../../../utils';
+import { CommandPaletteInputTheme } from './CommandPaletteInputTheme';
 
 export interface CommandPaletteInputProps {
   /**
@@ -58,6 +59,11 @@ export interface CommandPaletteInputProps {
    * When a hotkey was triggered. Used internally.
    */
   onHotkey: (hotkey: HotkeyIem) => void;
+
+  /**
+   * Theme for the Command Palette.
+   */
+  theme?: CommandPaletteTheme;
 }
 
 export const CommandPaletteInput: FC<CommandPaletteInputProps> = ({
@@ -69,7 +75,8 @@ export const CommandPaletteInput: FC<CommandPaletteInputProps> = ({
   onHotkey,
   onBlur,
   onChange,
-  onKeyPress
+  onKeyPress,
+  theme: customTheme
 }) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -94,8 +101,10 @@ export const CommandPaletteInput: FC<CommandPaletteInputProps> = ({
     };
   }, [onHotkey, hotkeys]);
 
-  const { input: inputTheme }: CommandPaletteTheme =
-    useComponentTheme('commandPalette');
+  const { input: inputTheme }: CommandPaletteTheme = useComponentTheme(
+    'commandPalette',
+    customTheme
+  );
 
   return (
     <div className={inputTheme.base}>

--- a/src/elements/CommandPalette/CommandPaletteItem/CommandPaletteItem.tsx
+++ b/src/elements/CommandPalette/CommandPaletteItem/CommandPaletteItem.tsx
@@ -6,38 +6,59 @@ import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../../utils';
 import { CommandPaletteTheme } from '../CommandPaletteTheme';
 
-export interface CommandPaletteItemProps extends ListItemProps {
+export interface CommandPaletteItemProps extends Omit<ListItemProps, 'theme'> {
   hotkey?: string;
+
+  /**
+   * Theme for the CommandPalette.
+   */
+  theme?: CommandPaletteTheme;
 }
 
 export const CommandPaletteItem = forwardRef<
   HTMLDivElement,
   CommandPaletteItemProps
->(({ children, active, className, end, hotkey, onClick, ...rest }, ref) => {
-  const { item: itemTheme }: CommandPaletteTheme =
-    useComponentTheme('commandPalette');
+>(
+  (
+    {
+      children,
+      active,
+      className,
+      end,
+      hotkey,
+      onClick,
+      theme: customTheme,
+      ...rest
+    },
+    ref
+  ) => {
+    const { item: itemTheme }: CommandPaletteTheme = useComponentTheme(
+      'commandPalette',
+      customTheme
+    );
 
-  return (
-    <MotionItem layout>
-      <ListItem
-        {...rest}
-        ref={ref}
-        className={twMerge(
-          itemTheme.base,
-          active && itemTheme.active,
-          onClick && itemTheme.clickable
-        )}
-        end={
-          <>
-            {hotkey && <Kbd keycode={hotkey} size="small" />}
-            {end}
-          </>
-        }
-      >
-        {children}
-      </ListItem>
-    </MotionItem>
-  );
-});
+    return (
+      <MotionItem layout>
+        <ListItem
+          {...rest}
+          ref={ref}
+          className={twMerge(
+            itemTheme.base,
+            active && itemTheme.active,
+            onClick && itemTheme.clickable
+          )}
+          end={
+            <>
+              {hotkey && <Kbd keycode={hotkey} size="small" />}
+              {end}
+            </>
+          }
+        >
+          {children}
+        </ListItem>
+      </MotionItem>
+    );
+  }
+);
 
 CommandPaletteItem.displayName = 'CommandPaletteItem';

--- a/src/elements/CommandPalette/CommandPaletteSection/CommandPaletteSection.tsx
+++ b/src/elements/CommandPalette/CommandPaletteSection/CommandPaletteSection.tsx
@@ -20,14 +20,21 @@ export interface CommandPaletteSectionProps extends PropsWithChildren {
    * Section stack index. Set internally.
    */
   index?: number;
+
+  /**
+   * Theme for the CommandPalette.
+   */
+  theme?: CommandPaletteTheme;
 }
 
 export const CommandPaletteSection = forwardRef<
   HTMLDivElement,
   CommandPaletteSectionProps
->(({ children, className, title, index, ...rest }, ref) => {
-  const { section: sectionTheme }: CommandPaletteTheme =
-    useComponentTheme('commandPalette');
+>(({ children, className, title, index, theme: customTheme, ...rest }, ref) => {
+  const { section: sectionTheme }: CommandPaletteTheme = useComponentTheme(
+    'commandPalette',
+    customTheme
+  );
 
   return (
     <MotionItem layout>

--- a/src/elements/Kbd/Kbd.tsx
+++ b/src/elements/Kbd/Kbd.tsx
@@ -5,11 +5,21 @@ import { useComponentTheme } from '../../utils';
 import { KbdTheme } from './KbdTheme';
 import { twMerge } from 'tailwind-merge';
 
-export interface KbdProps extends Omit<ChipProps, 'children'> {
+export interface KbdProps extends Omit<ChipProps, 'children' | 'theme'> {
   keycode: string;
+
+  /**
+   * Theme for the Kbd.
+   */
+  theme?: KbdTheme;
 }
 
-export const Kbd: FC<KbdProps> = ({ className, keycode, ...rest }) => {
+export const Kbd: FC<KbdProps> = ({
+  className,
+  keycode,
+  theme: customTheme,
+  ...rest
+}) => {
   const split = keycode.split('+').map(getHotkeyText);
   const theme: KbdTheme = useComponentTheme('kbd');
 

--- a/src/elements/Loader/DotsLoader.tsx
+++ b/src/elements/Loader/DotsLoader.tsx
@@ -8,10 +8,16 @@ export interface DotsLoaderProps {
   className?: string;
   speed?: number;
   size?: 'small' | 'medium' | 'large';
+  theme?: DotsLoaderTheme;
 }
 
-export const DotsLoader: FC<DotsLoaderProps> = ({ className, size, speed }) => {
-  const theme: DotsLoaderTheme = useComponentTheme('dotsLoader');
+export const DotsLoader: FC<DotsLoaderProps> = ({
+  className,
+  size,
+  speed,
+  theme: customTheme
+}) => {
+  const theme: DotsLoaderTheme = useComponentTheme('dotsLoader', customTheme);
 
   return (
     <motion.div className={twMerge(theme.base, className)}>

--- a/src/form/Calendar/Calendar.tsx
+++ b/src/form/Calendar/Calendar.tsx
@@ -91,6 +91,11 @@ export interface CalendarProps {
    * A callback function that is called when the calendar view changes.
    */
   onViewChange?: (view: CalendarViewType) => void;
+
+  /**
+   * Theme for the Calendar.
+   */
+  theme?: CalendarTheme;
 }
 
 export const Calendar: FC<CalendarProps> = ({
@@ -104,9 +109,10 @@ export const Calendar: FC<CalendarProps> = ({
   showDayOfWeek,
   animated,
   onChange,
-  onViewChange
+  onViewChange,
+  theme: customTheme
 }) => {
-  const theme = useComponentTheme('calendar') as CalendarTheme;
+  const theme: CalendarTheme = useComponentTheme('calendar', customTheme);
 
   const date = useMemo(
     () => (Array.isArray(value) ? value[0] : value ?? new Date()),

--- a/src/form/Calendar/CalendarDays/CalendarDays.tsx
+++ b/src/form/Calendar/CalendarDays/CalendarDays.tsx
@@ -98,6 +98,11 @@ export interface CalendarDaysProps {
    * A callback function that is called when a day is hovered.
    */
   onHover?: (date: Date | null) => void;
+
+  /**
+   * Theme for the CalendarDays.
+   */
+  theme?: CalendarTheme;
 }
 
 export const CalendarDays: FC<CalendarDaysProps> = ({
@@ -115,9 +120,10 @@ export const CalendarDays: FC<CalendarDaysProps> = ({
   hidePrevMonthDays,
   hideNextMonthDays,
   onChange,
-  onHover
+  onHover,
+  theme: customTheme
 }) => {
-  const { days } = useComponentTheme('calendar') as CalendarTheme;
+  const { days }: CalendarTheme = useComponentTheme('calendar', customTheme);
 
   const [hoveringDate, setHoveringDate] = useState<Date | null>(hover);
   const weeks = useMemo(() => getWeeks(value), [value]);

--- a/src/form/Calendar/CalendarMonths/CalendarMonths.tsx
+++ b/src/form/Calendar/CalendarMonths/CalendarMonths.tsx
@@ -15,13 +15,19 @@ export interface CalendarMonthsProps {
    * A callback function that is called when a day is selected.
    */
   onChange: (month: number) => void;
+
+  /**
+   * Theme for the CalendarMonths.
+   */
+  theme?: CalendarTheme;
 }
 
 export const CalendarMonths: FC<CalendarMonthsProps> = ({
   value,
-  onChange
+  onChange,
+  theme: customTheme
 }) => {
-  const { months } = useComponentTheme('calendar') as CalendarTheme;
+  const { months }: CalendarTheme = useComponentTheme('calendar', customTheme);
 
   return (
     <div className={twMerge(months.root)}>

--- a/src/form/Calendar/CalendarRange.tsx
+++ b/src/form/Calendar/CalendarRange.tsx
@@ -11,7 +11,7 @@ import { useComponentTheme } from '../../utils';
 import { CalendarRangeTheme } from './CalendarRangeTheme';
 
 export interface CalendarRangeProps
-  extends Omit<CalendarProps, 'value' | 'isRange' | 'onViewChange'> {
+  extends Omit<CalendarProps, 'value' | 'isRange' | 'onViewChange' | 'theme'> {
   /**
    * The selected date(s) for the calendar.
    */
@@ -40,6 +40,11 @@ export interface CalendarRangeProps
    * The text or icon to use for previous year.
    */
   previousYearArrow?: React.ReactNode | string;
+
+  /**
+   * Theme for the CalendarRange.
+   */
+  theme?: CalendarRangeTheme;
 }
 
 export const CalendarRange: FC<CalendarRangeProps> = ({
@@ -57,9 +62,13 @@ export const CalendarRange: FC<CalendarRangeProps> = ({
   onChange,
   monthsToDisplay,
   direction,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme = useComponentTheme('calendarRange') as CalendarRangeTheme;
+  const theme: CalendarRangeTheme = useComponentTheme(
+    'calendarRange',
+    customTheme
+  );
   const date = useMemo(
     () => (Array.isArray(value) ? value[0] : new Date()),
     [value]

--- a/src/form/Calendar/CalendarYears/CalendarYears.tsx
+++ b/src/form/Calendar/CalendarYears/CalendarYears.tsx
@@ -35,6 +35,11 @@ export interface CalendarYearsProps {
    * A callback function that is called when a year is selected.
    */
   onChange: (year: number) => void;
+
+  /**
+   * Theme for the CalendarYears.
+   */
+  theme?: CalendarTheme;
 }
 
 export const CalendarYears: FC<CalendarYearsProps> = ({
@@ -43,9 +48,10 @@ export const CalendarYears: FC<CalendarYearsProps> = ({
   value,
   animated,
   xAnimation = 0,
-  onChange
+  onChange,
+  theme: customTheme
 }) => {
-  const { years } = useComponentTheme('calendar') as CalendarTheme;
+  const { years }: CalendarTheme = useComponentTheme('calendar', customTheme);
 
   const yearDates = useMemo(() => {
     const arr = [];

--- a/src/form/Checkbox/Checkbox.tsx
+++ b/src/form/Checkbox/Checkbox.tsx
@@ -69,6 +69,11 @@ export interface CheckboxProps {
    * Event handler for when the checkbox is blurred.
    */
   onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
+
+  /**
+   * Theme for the Checkbox.
+   */
+  theme?: CheckboxTheme;
 }
 
 export interface CheckboxRef {
@@ -91,11 +96,12 @@ export const Checkbox: FC<CheckboxProps & CheckboxRef> = forwardRef(
       borderPath = 'M 0 0 L 0 16 L 16 16 L 16 0 Z',
       checkedPath = 'M 5.36396 8.17792 L 7.34236 9.91424 L 10.6044 5.832',
       intermediatePath = 'M 5.36396 8.17792 L 10.6044 8.17792',
+      theme: customTheme,
       ...rest
     },
     ref
   ) => {
-    const theme: CheckboxTheme = useComponentTheme('checkbox');
+    const theme: CheckboxTheme = useComponentTheme('checkbox', customTheme);
     const pathLength = useMotionValue(0);
     const opacity = useTransform(pathLength, [0.05, 0.15], [0, 1]);
 

--- a/src/form/Input/InlineInput/InlineInput.tsx
+++ b/src/form/Input/InlineInput/InlineInput.tsx
@@ -31,14 +31,24 @@ export interface InlineInputProps
    * onAutosize handler
    */
   onAutosize?: (newWidth: number) => void;
+
+  /**
+   * Theme for the InlineInput.
+   */
+  theme?: InputTheme;
 }
 
 export const InlineInput: FC<InlineInputProps> = forwardRef(
   (
-    { inputClassName, placeholderIsMinWidth = true, ...rest },
+    {
+      inputClassName,
+      placeholderIsMinWidth = true,
+      theme: customTheme,
+      ...rest
+    },
     ref: Ref<InputRef>
   ) => {
-    const theme: InputTheme = useComponentTheme('input');
+    const theme: InputTheme = useComponentTheme('input', customTheme);
 
     return (
       <AutosizeInput

--- a/src/form/Input/Input.tsx
+++ b/src/form/Input/Input.tsx
@@ -50,6 +50,11 @@ export interface InputProps
    * Shortcut for the onChange value event.
    */
   onValueChange?: (value: string) => void;
+
+  /**
+   * Theme for the Input.
+   */
+  theme?: InputTheme;
 }
 
 export interface InputRef {
@@ -77,6 +82,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       onFocus,
       onChange,
       onValueChange,
+      theme: customTheme,
       ...rest
     },
     ref
@@ -99,7 +105,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       }
     }, [autoFocus]);
 
-    const theme: InputTheme = useComponentTheme('input');
+    const theme: InputTheme = useComponentTheme('input', customTheme);
 
     return (
       <div

--- a/src/form/Radio/Radio.tsx
+++ b/src/form/Radio/Radio.tsx
@@ -48,6 +48,11 @@ export interface RadioProps {
    * Required when `Radio` is used within a `RadioGroup`
    */
   value?: any;
+
+  /**
+   * Theme for the Radio.
+   */
+  theme?: RadioTheme;
 }
 
 const VARIANTS = {
@@ -70,6 +75,7 @@ export const Radio: FC<RadioProps & RadioRef> = forwardRef(
       className,
       size,
       value,
+      theme: customTheme,
       ...rest
     },
     ref
@@ -89,7 +95,7 @@ export const Radio: FC<RadioProps & RadioRef> = forwardRef(
       onChange?.(checked);
     };
 
-    const theme: RadioTheme = useComponentTheme('radio');
+    const theme: RadioTheme = useComponentTheme('radio', customTheme);
 
     return (
       <div className={twMerge(theme.base, className)}>

--- a/src/form/Range/RangeDouble.tsx
+++ b/src/form/Range/RangeDouble.tsx
@@ -10,6 +10,7 @@ import { motion, useMotionValue } from 'framer-motion';
 import { RangeProps, RangeTooltip } from './RangeTooltip';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { RangeTheme } from './RangeTheme';
 
 export const RangeDouble: FC<RangeProps<[number, number]>> = ({
   disabled,
@@ -20,6 +21,7 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
   max,
   value,
   onChange,
+  theme: customTheme,
   step = 1
 }) => {
   const minValueBetween = step;
@@ -119,7 +121,7 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
   const maxTooltipVisible = draggingMax || focusedMax || hoveringMax;
   const maxPercentage = ((currentMax - min) / (max - min)) * 100;
 
-  const theme = useComponentTheme('range');
+  const theme: RangeTheme = useComponentTheme('range', customTheme);
 
   return (
     <div

--- a/src/form/Range/RangeSingle.tsx
+++ b/src/form/Range/RangeSingle.tsx
@@ -10,6 +10,7 @@ import { motion, useMotionValue } from 'framer-motion';
 import { RangeProps, RangeTooltip } from './RangeTooltip';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { RangeTheme } from './RangeTheme';
 
 export const RangeSingle: FC<RangeProps<number>> = ({
   disabled,
@@ -20,7 +21,8 @@ export const RangeSingle: FC<RangeProps<number>> = ({
   min,
   max,
   value,
-  step = 1
+  step = 1,
+  theme: customTheme
 }) => {
   const [currentValue, setCurrentValue] = useState<number>(value);
 
@@ -76,7 +78,7 @@ export const RangeSingle: FC<RangeProps<number>> = ({
   const [focused, setFocused] = useState(false);
   const tooltipVisible = dragging || focused || hovering;
 
-  const theme = useComponentTheme('range');
+  const theme: RangeTheme = useComponentTheme('range', customTheme);
 
   return (
     <div

--- a/src/form/Range/RangeTooltip.tsx
+++ b/src/form/Range/RangeTooltip.tsx
@@ -49,6 +49,11 @@ export interface RangeProps<Value> {
    * Event fired when the range value changes
    */
   onChange?: (value: Value) => void;
+
+  /**
+   * Theme for the range
+   */
+  theme?: RangeTheme;
 }
 
 export interface RangeTooltipProps {

--- a/src/form/Select/SelectInput/SelectInput.tsx
+++ b/src/form/Select/SelectInput/SelectInput.tsx
@@ -44,6 +44,7 @@ export interface SelectInputProps {
   clearable?: boolean;
   refreshable?: boolean;
   menuDisabled?: boolean;
+  theme?: SelectTheme;
 
   closeIcon?: React.ReactNode;
   refreshIcon?: React.ReactNode;
@@ -108,9 +109,13 @@ export const SelectInput: FC<Partial<SelectInputProps>> = ({
   onFocus,
   onBlur,
   onRefresh,
-  chip
+  chip,
+  theme: customTheme
 }) => {
-  const { selectInput: theme }: SelectTheme = useComponentTheme('select');
+  const { selectInput: theme }: SelectTheme = useComponentTheme(
+    'select',
+    customTheme
+  );
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<any | null>(null);
 

--- a/src/form/Select/SelectInput/SelectInputChip.tsx
+++ b/src/form/Select/SelectInput/SelectInputChip.tsx
@@ -12,6 +12,7 @@ export interface SelectInputChipProps {
   className?: string;
   disabled?: boolean;
   clearable?: boolean;
+  theme?: SelectTheme;
   closeIcon?: React.ReactNode;
   onTagKeyDown: (
     event: React.KeyboardEvent<HTMLSpanElement>,
@@ -28,13 +29,17 @@ export const SelectInputChip: FC<Partial<SelectInputChipProps>> = ({
   maxLength,
   closeIcon,
   onTagKeyDown,
-  onSelectedChange
+  onSelectedChange,
+  theme: customTheme
 }) => {
   const origLabel = option.inputLabel || option.children;
   const label =
     typeof origLabel === 'string' ? ellipsize(origLabel, maxLength) : origLabel;
 
-  const { selectInput: theme }: SelectTheme = useComponentTheme('select');
+  const { selectInput: theme }: SelectTheme = useComponentTheme(
+    'select',
+    customTheme
+  );
 
   return (
     <span

--- a/src/form/Select/SelectMenu/SelectMenu.tsx
+++ b/src/form/Select/SelectMenu/SelectMenu.tsx
@@ -78,6 +78,11 @@ export interface SelectMenuProps {
    * Event fired when the selected option(s) change.
    */
   onSelectedChange: (option: SelectValue) => void;
+
+  /**
+   * The theme for the Select.
+   */
+  theme?: SelectTheme;
 }
 
 export const SelectMenu: FC<Partial<SelectMenuProps>> = ({
@@ -93,7 +98,8 @@ export const SelectMenu: FC<Partial<SelectMenuProps>> = ({
   groups,
   multiple,
   inputSearchText,
-  onSelectedChange
+  onSelectedChange,
+  theme: customTheme
 }) => {
   const trimmedText = inputSearchText.trim();
 
@@ -112,7 +118,10 @@ export const SelectMenu: FC<Partial<SelectMenuProps>> = ({
     [selectedOption, multiple]
   );
 
-  const { selectMenu: theme }: SelectTheme = useComponentTheme('select');
+  const { selectMenu: theme }: SelectTheme = useComponentTheme(
+    'select',
+    customTheme
+  );
 
   const renderListItems = useCallback(
     (items: SelectOptionProps[], group?: GroupOption) =>

--- a/src/form/Textarea/Textarea.tsx
+++ b/src/form/Textarea/Textarea.tsx
@@ -31,6 +31,11 @@ export interface TextareaProps extends TextareaAutosizeProps {
    * Size of the field.
    */
   size?: 'small' | 'medium' | 'large';
+
+  /**
+   * Theme for the Textarea.
+   */
+  theme?: TextareaTheme;
 }
 
 export interface TextAreaRef {
@@ -48,6 +53,7 @@ export const Textarea = forwardRef<TextAreaRef, TextareaProps>(
       containerClassName,
       className,
       error,
+      theme: customTheme,
       ...rest
     },
     ref
@@ -62,7 +68,7 @@ export const Textarea = forwardRef<TextAreaRef, TextareaProps>(
       focus: () => inputRef.current?.focus()
     }));
 
-    const theme: TextareaTheme = useComponentTheme('textarea');
+    const theme: TextareaTheme = useComponentTheme('textarea', customTheme);
 
     return (
       <div

--- a/src/form/Toggle/Toggle.tsx
+++ b/src/form/Toggle/Toggle.tsx
@@ -34,6 +34,11 @@ export interface ToggleProps {
    * When the toggle was blurred.
    */
   onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
+
+  /**
+   * Theme for the Toggle.
+   */
+  theme?: ToggleTheme;
 }
 
 export interface ToggleRef {
@@ -41,8 +46,20 @@ export interface ToggleRef {
 }
 
 export const Toggle: FC<ToggleProps & ToggleRef> = forwardRef(
-  ({ checked, disabled, onChange, onBlur, className, size, ...rest }, ref) => {
-    const theme: ToggleTheme = useComponentTheme('toggle');
+  (
+    {
+      checked,
+      disabled,
+      onChange,
+      onBlur,
+      className,
+      size,
+      theme: customTheme,
+      ...rest
+    },
+    ref
+  ) => {
+    const theme: ToggleTheme = useComponentTheme('toggle', customTheme);
 
     return (
       <div

--- a/src/layers/ContextMenu/ContextMenu.tsx
+++ b/src/layers/ContextMenu/ContextMenu.tsx
@@ -49,6 +49,11 @@ export interface ContextMenuProps extends Omit<ConnectedOverlayProps, 'open'> {
    * Class name to apply to the trigger when the context menu is open.
    */
   triggerOpenClassName?: string;
+
+  /**
+   * Theme for the Context Menu.
+   */
+  theme?: ContextMenuTheme;
 }
 
 export const ContextMenu: FC<ContextMenuProps> = ({
@@ -59,6 +64,7 @@ export const ContextMenu: FC<ContextMenuProps> = ({
   triggerOpenClassName,
   autofocus,
   autoClose,
+  theme: customTheme,
   ...rest
 }) => {
   const id = useId();
@@ -93,7 +99,7 @@ export const ContextMenu: FC<ContextMenuProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [closeAll]);
-  const theme: ContextMenuTheme = useComponentTheme('contextMenu');
+  const theme: ContextMenuTheme = useComponentTheme('contextMenu', customTheme);
 
   return (
     <ConnectedOverlay

--- a/src/layers/Dialog/Dialog.tsx
+++ b/src/layers/Dialog/Dialog.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import { twMerge } from 'tailwind-merge';
 import { DialogHeader, DialogHeaderProps } from './DialogHeader';
 import { useComponentTheme } from '../../utils';
+import { DialogTheme } from './DialogTheme';
 
 export interface DialogProps extends Omit<GlobalOverlayProps, 'children'> {
   /**
@@ -57,6 +58,11 @@ export interface DialogProps extends Omit<GlobalOverlayProps, 'children'> {
    * The React element for the dialog header.
    */
   headerElement: ReactElement<DialogHeaderProps, typeof DialogHeader> | null;
+
+  /**
+   * Theme for the Dialog.
+   */
+  theme?: DialogTheme;
 }
 
 export const Dialog: FC<Partial<DialogProps>> = ({
@@ -74,10 +80,11 @@ export const Dialog: FC<Partial<DialogProps>> = ({
   hasBackdrop,
   showCloseButton,
   closeOnBackdropClick,
-  closeOnEscape
+  closeOnEscape,
+  theme: customTheme
 }) => {
   const id = useId();
-  const theme = useComponentTheme('dialog');
+  const theme: DialogTheme = useComponentTheme('dialog', customTheme);
 
   return (
     <GlobalOverlay

--- a/src/layers/Dialog/DialogHeader.tsx
+++ b/src/layers/Dialog/DialogHeader.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { DialogTheme } from './DialogTheme';
 
 export interface DialogHeaderProps {
   children?: any;
@@ -8,6 +9,7 @@ export interface DialogHeaderProps {
   showCloseButton?: boolean;
   disablePadding?: boolean;
   onClose?: () => void;
+  theme?: DialogTheme;
 }
 
 export const DialogHeader: FC<Partial<DialogHeaderProps>> = ({
@@ -15,9 +17,10 @@ export const DialogHeader: FC<Partial<DialogHeaderProps>> = ({
   className,
   showCloseButton,
   disablePadding,
-  onClose
+  onClose,
+  theme: customTheme
 }) => {
-  const theme = useComponentTheme('dialog');
+  const theme = useComponentTheme('dialog', customTheme);
 
   return (
     <header

--- a/src/layers/Drawer/Drawer.tsx
+++ b/src/layers/Drawer/Drawer.tsx
@@ -19,6 +19,7 @@ export interface DrawerProps extends Omit<GlobalOverlayProps, 'children'> {
   showCloseButton?: boolean;
   children?: any;
   headerElement: ReactElement<DrawerHeaderProps, typeof DrawerHeader> | null;
+  theme?: DrawerTheme;
 }
 
 export const Drawer: FC<Partial<DrawerProps>> = ({
@@ -36,7 +37,8 @@ export const Drawer: FC<Partial<DrawerProps>> = ({
   closeOnBackdropClick,
   disablePadding,
   showCloseButton,
-  onClose
+  onClose,
+  theme: customTheme
 }) => {
   const id = useId();
   const variant = variants[position];
@@ -46,7 +48,7 @@ export const Drawer: FC<Partial<DrawerProps>> = ({
     height: position === 'top' || position === 'bottom' ? size : 'auto'
   };
 
-  const theme: DrawerTheme = useComponentTheme('drawer');
+  const theme: DrawerTheme = useComponentTheme('drawer', customTheme);
 
   return (
     <GlobalOverlay

--- a/src/layers/Drawer/DrawerHeader.tsx
+++ b/src/layers/Drawer/DrawerHeader.tsx
@@ -8,15 +8,17 @@ export interface DrawerHeaderProps {
   className?: string;
   showCloseButton?: boolean;
   onClose?: () => void;
+  theme?: DrawerTheme;
 }
 
 export const DrawerHeader: FC<Partial<DrawerHeaderProps>> = ({
   children,
   className,
   showCloseButton,
-  onClose
+  onClose,
+  theme: customTheme
 }) => {
-  const theme: DrawerTheme = useComponentTheme('drawer');
+  const theme: DrawerTheme = useComponentTheme('drawer', customTheme);
 
   return (
     <header className={twMerge(theme.header.base, className)}>

--- a/src/layers/Menu/Menu.tsx
+++ b/src/layers/Menu/Menu.tsx
@@ -97,6 +97,11 @@ export interface MenuProps {
    * Mouse leave event.
    */
   onMouseLeave: (event) => void;
+
+  /**
+   * Theme for the Menu.
+   */
+  theme?: MenuTheme;
 }
 
 export interface MenuRef {
@@ -123,7 +128,8 @@ export const Menu: FC<Partial<MenuProps & MenuRef>> = forwardRef(
       maxWidth,
       onClose,
       onMouseEnter,
-      onMouseLeave
+      onMouseLeave,
+      theme: customTheme
     },
     ref
   ) => {
@@ -170,7 +176,7 @@ export const Menu: FC<Partial<MenuProps & MenuRef>> = forwardRef(
       return modifiers;
     }, [modifiers, autoWidth, minWidth, maxWidth]);
 
-    const theme: MenuTheme = useComponentTheme('menu');
+    const theme: MenuTheme = useComponentTheme('menu', customTheme);
 
     return (
       <ConnectedOverlay

--- a/src/layers/Notification/Notification.tsx
+++ b/src/layers/Notification/Notification.tsx
@@ -9,6 +9,7 @@ export interface NotificationProps extends NotificationOptions {
   id: number;
   component?: ReactNode;
   onClose: (id: number) => void;
+  theme?: NotificationTheme;
 }
 
 export const Notification: FC<NotificationProps> = ({
@@ -20,7 +21,8 @@ export const Notification: FC<NotificationProps> = ({
   className,
   variant,
   component,
-  onClose
+  onClose,
+  theme: customTheme
 }) => {
   const timeoutRef = useRef<any | null>(null);
 
@@ -36,7 +38,10 @@ export const Notification: FC<NotificationProps> = ({
     return () => clearTimer();
   }, [clearTimer, startTimer]);
 
-  const theme: NotificationTheme = useComponentTheme('notification');
+  const theme: NotificationTheme = useComponentTheme(
+    'notification',
+    customTheme
+  );
 
   return (
     <motion.div

--- a/src/layers/Notification/Notifications.tsx
+++ b/src/layers/Notification/Notifications.tsx
@@ -34,6 +34,7 @@ export interface NotificationsProps {
   components?: {
     [variant in NotificationVariants]?: JSXElementConstructor<NotificationComponentProps>;
   };
+  theme?: NotificationTheme;
 }
 
 // Hacky way to track unique versions of a notification
@@ -46,7 +47,8 @@ export const Notifications: FC<NotificationsProps> = ({
   showClose,
   className,
   preventFlooding,
-  components
+  components,
+  theme: customTheme
 }) => {
   const [notifications, setNotifications] = useState<any[]>([]);
 
@@ -127,7 +129,10 @@ export const Notifications: FC<NotificationsProps> = ({
     ]
   );
 
-  const theme: NotificationTheme = useComponentTheme('notification');
+  const theme: NotificationTheme = useComponentTheme(
+    'notification',
+    customTheme
+  );
 
   return (
     <Fragment>

--- a/src/layers/Popover/Popover.tsx
+++ b/src/layers/Popover/Popover.tsx
@@ -6,7 +6,7 @@ import { twMerge } from 'tailwind-merge';
 import { PopoverTheme } from './PopoverTheme';
 import { useComponentTheme } from '../../utils';
 
-export interface PopoverProps extends Partial<TooltipProps> {
+export interface PopoverProps extends Partial<Omit<TooltipProps, 'theme'>> {
   /**
    * Disable default padding on popover.
    */
@@ -21,6 +21,11 @@ export interface PopoverProps extends Partial<TooltipProps> {
    * Popover classname.
    */
   popoverClassName?: string;
+
+  /**
+   * Theme for the Popover.
+   */
+  theme?: PopoverTheme;
 }
 
 export const Popover: FC<PopoverProps> = ({
@@ -34,10 +39,11 @@ export const Popover: FC<PopoverProps> = ({
   disablePadding,
   popoverStyle,
   popoverClassName,
+  theme: customTheme,
   ...rest
 }) => {
   const id = useId();
-  const theme: PopoverTheme = useComponentTheme('popover');
+  const theme: PopoverTheme = useComponentTheme('popover', customTheme);
 
   return (
     <Tooltip

--- a/src/layers/Tooltip/Tooltip.story.tsx
+++ b/src/layers/Tooltip/Tooltip.story.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Tooltip } from './Tooltip';
 import { Button } from '../../elements';
+import { extendComponentTheme } from '../../utils';
+import { darkTooltipTheme, TooltipTheme } from './TooltipTheme';
 
 export default {
   title: 'Components/Layers/Tooltip',
@@ -23,6 +25,33 @@ export const Simple = () => (
     <Tooltip content="Hi there too">Hover me too</Tooltip>
   </div>
 );
+
+export const CustomTheme = () => {
+  const customTheme = extendComponentTheme<TooltipTheme>(darkTooltipTheme, {
+    base: 'rounded bg-green-800 text-white font-bold p-3 text-base'
+  });
+
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        width: '100%',
+        margin: '50px',
+        color: 'green'
+      }}
+    >
+      <Tooltip theme={customTheme} content="Hi there">
+        Hover me
+      </Tooltip>
+      <br />
+      <br />
+      <br />
+      <Tooltip theme={customTheme} content="Hi there too">
+        Hover me too
+      </Tooltip>
+    </div>
+  );
+};
 
 export const Disabled = () => (
   <div style={{ textAlign: 'center', width: '100%', margin: '50px' }}>

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -111,6 +111,11 @@ export interface TooltipProps {
    * Tooltip was closed.
    */
   onClose?(): void;
+
+  /**
+   * Theme for the tooltip.
+   */
+  theme?: TooltipTheme;
 }
 
 export const Tooltip: FC<Partial<TooltipProps>> = ({
@@ -132,6 +137,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
   isPopover,
   onOpen,
   onClose,
+  theme: customTheme,
   ...rest
 }) => {
   const { addTooltip, deactivateTooltip, deactivateAllTooltips } =
@@ -169,7 +175,7 @@ export const Tooltip: FC<Partial<TooltipProps>> = ({
     };
   }, [deactivateTooltip, isPopover, visible]);
 
-  const theme: TooltipTheme = useComponentTheme('tooltip');
+  const theme: TooltipTheme = useComponentTheme('tooltip', customTheme);
 
   return (
     <ConnectedOverlay

--- a/src/layout/Block/Block.tsx
+++ b/src/layout/Block/Block.tsx
@@ -50,6 +50,11 @@ export interface BlockProps extends React.HTMLAttributes<HTMLElement> {
   onTitleClick?: (
     event: React.MouseEvent<HTMLLabelElement, MouseEvent>
   ) => void;
+
+  /**
+   * Theme for the Block.
+   */
+  theme?: BlockTheme;
 }
 
 export const Block: FC<BlockProps> = ({
@@ -62,9 +67,10 @@ export const Block: FC<BlockProps> = ({
   direction,
   alignment,
   onTitleClick,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme: BlockTheme = useComponentTheme('block');
+  const theme: BlockTheme = useComponentTheme('block', customTheme);
 
   return (
     <section

--- a/src/layout/Card/Card.tsx
+++ b/src/layout/Card/Card.tsx
@@ -33,6 +33,11 @@ export interface CardProps extends React.DOMAttributes<any> {
    * Header element or text to show.
    */
   header?: string | React.JSX.Element | React.JSX.Element[];
+
+  /**
+   * Theme for the Card.
+   */
+  theme?: CardTheme;
 }
 
 export type CardRefProps = CardProps & { ref?: LegacyRef<HTMLDivElement> };
@@ -46,11 +51,12 @@ export const Card: FC<CardRefProps> = forwardRef(
       header,
       headerClassName,
       contentClassName,
+      theme: customTheme,
       ...rest
     }: CardProps,
     ref
   ) => {
-    const theme: CardTheme = useComponentTheme('card');
+    const theme: CardTheme = useComponentTheme('card', customTheme);
 
     return (
       <section

--- a/src/layout/Collapse/Collapse.tsx
+++ b/src/layout/Collapse/Collapse.tsx
@@ -33,15 +33,21 @@ export interface CollapseProps
    * Children to render.
    */
   children?: React.ReactNode | (() => React.ReactNode);
+
+  /**
+   * Theme for the Collapse.
+   */
+  theme?: CollapseTheme;
 }
 
 export const Collapse: FC<CollapseProps> = ({
   children,
   expanded,
   className,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme: CollapseTheme = useComponentTheme('collapse');
+  const theme: CollapseTheme = useComponentTheme('collapse', customTheme);
 
   return (
     <AnimatePresence initial={false}>

--- a/src/layout/Divider/Divider.tsx
+++ b/src/layout/Divider/Divider.tsx
@@ -24,15 +24,21 @@ export interface DividerProps {
    * Additional style attributes. Recommend to use css classes over this.
    */
   style?: React.CSSProperties;
+
+  /**
+   * Theme for the Divider.
+   */
+  theme?: DividerTheme;
 }
 
 export const Divider: FC<DividerProps> = ({
   className,
   disableMargins,
   orientation,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme = useComponentTheme('divider') as DividerTheme;
+  const theme: DividerTheme = useComponentTheme('divider', customTheme);
 
   return (
     <hr

--- a/src/layout/List/List.tsx
+++ b/src/layout/List/List.tsx
@@ -3,11 +3,16 @@ import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
 import { ListTheme } from './ListTheme';
 
-export type ListProps = InputHTMLAttributes<HTMLDivElement>;
+export type ListProps = InputHTMLAttributes<HTMLDivElement> & {
+  /**
+   * Theme for the List.
+   */
+  theme?: ListTheme;
+};
 
 export const List = forwardRef<HTMLDivElement, ListProps>(
-  ({ className, children, ...rest }, ref) => {
-    const theme: ListTheme = useComponentTheme('list');
+  ({ className, children, theme: customTheme, ...rest }, ref) => {
+    const theme: ListTheme = useComponentTheme('list', customTheme);
     return (
       <div
         {...rest}

--- a/src/layout/List/ListHeader/ListHeader.tsx
+++ b/src/layout/List/ListHeader/ListHeader.tsx
@@ -4,14 +4,20 @@ import { ListTheme } from '../ListTheme';
 import { useComponentTheme } from '../../../utils';
 import { twMerge } from 'tailwind-merge';
 
-export type ListHeaderProps = InputHTMLAttributes<HTMLDivElement>;
+export type ListHeaderProps = InputHTMLAttributes<HTMLDivElement> & {
+  /**
+   * Theme for the List.
+   */
+  theme?: ListTheme;
+};
 
 export const ListHeader: FC<ListHeaderProps> = ({
   className,
   children,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme: ListTheme = useComponentTheme('list');
+  const theme: ListTheme = useComponentTheme('list', customTheme);
   return (
     <Sub {...(rest as any)} className={twMerge(className, theme.header)}>
       {children}

--- a/src/layout/List/ListItem/ListItem.tsx
+++ b/src/layout/List/ListItem/ListItem.tsx
@@ -38,6 +38,11 @@ export interface ListItemProps extends InputHTMLAttributes<HTMLDivElement> {
    * A end component for the list item.
    */
   end?: React.ReactNode;
+
+  /**
+   * Theme for the List.
+   */
+  theme?: ListTheme;
 }
 
 export const ListItem = forwardRef<HTMLDivElement, ListItemProps>(
@@ -53,11 +58,12 @@ export const ListItem = forwardRef<HTMLDivElement, ListItemProps>(
       end,
       dense,
       onClick,
+      theme: customTheme,
       ...rest
     },
     ref
   ) => {
-    const theme: ListTheme = useComponentTheme('list');
+    const theme: ListTheme = useComponentTheme('list', customTheme);
 
     return (
       <div

--- a/src/layout/Stack/Stack.tsx
+++ b/src/layout/Stack/Stack.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, HTMLAttributes } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { StackTheme } from './StackTheme';
 
 export interface StackProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -27,6 +28,11 @@ export interface StackProps extends HTMLAttributes<HTMLDivElement> {
    * How the content is arranged inside the stack.
    */
   justifyContent?: 'start' | 'end' | 'center' | 'spaceBetween';
+
+  /**
+   * Theme for the Stack.
+   */
+  theme?: StackTheme;
 }
 
 export const Stack = forwardRef<HTMLDivElement, StackProps>(
@@ -39,11 +45,12 @@ export const Stack = forwardRef<HTMLDivElement, StackProps>(
       inline,
       alignItems,
       justifyContent,
+      theme: customTheme,
       ...otherProps
     },
     ref
   ) => {
-    const theme = useComponentTheme('stack');
+    const theme: StackTheme = useComponentTheme('stack', customTheme);
 
     return (
       <div

--- a/src/layout/Tabs/Tab.tsx
+++ b/src/layout/Tabs/Tab.tsx
@@ -36,6 +36,11 @@ export interface TabProps extends PropsWithChildren {
    * @private
    */
   onSelect?: () => void;
+
+  /**
+   * Theme for the Tabs.
+   */
+  theme?: TabsTheme;
 }
 
 export const Tab: FC<TabProps> = ({
@@ -44,9 +49,10 @@ export const Tab: FC<TabProps> = ({
   selected,
   className,
   disabled,
-  onSelect
+  onSelect,
+  theme: customTheme
 }) => {
-  const theme: TabsTheme = useComponentTheme('tabs');
+  const theme: TabsTheme = useComponentTheme('tabs', customTheme);
 
   return (
     <span>

--- a/src/layout/Tabs/TabList.tsx
+++ b/src/layout/Tabs/TabList.tsx
@@ -34,6 +34,11 @@ export interface TabListProps extends PropsWithChildren {
    * @private
    */
   onSelect?: (index: number) => void;
+
+  /**
+   * Theme for the Tabs.
+   */
+  theme?: TabsTheme;
 }
 
 export const TabList: FC<TabListProps> = ({
@@ -42,9 +47,10 @@ export const TabList: FC<TabListProps> = ({
   direction,
   className,
   selectedIndex,
-  onSelect
+  onSelect,
+  theme: customTheme
 }) => {
-  const theme: TabsTheme = useComponentTheme('tabs');
+  const theme: TabsTheme = useComponentTheme('tabs', customTheme);
 
   const childs = Children.toArray(children)
     .filter((child: any) => child.type?.name === Tab.name)

--- a/src/layout/Tabs/TabPanel.tsx
+++ b/src/layout/Tabs/TabPanel.tsx
@@ -8,10 +8,19 @@ export interface TabPanelProps extends PropsWithChildren {
    * The class name to be added to the tab panel.
    */
   className?: string;
+
+  /**
+   * Theme for the Tabs.
+   */
+  theme?: TabsTheme;
 }
 
-export const TabPanel: FC<TabPanelProps> = ({ children, className }) => {
-  const theme: TabsTheme = useComponentTheme('tabs');
+export const TabPanel: FC<TabPanelProps> = ({
+  children,
+  className,
+  theme: customTheme
+}) => {
+  const theme: TabsTheme = useComponentTheme('tabs', customTheme);
   return (
     <section role="tabpanel" className={twMerge(theme.panel, className)}>
       {children}

--- a/src/layout/Tabs/Tabs.tsx
+++ b/src/layout/Tabs/Tabs.tsx
@@ -45,6 +45,11 @@ export interface TabsProps extends PropsWithChildren {
    * The callback to be called when a tab is selected.
    */
   onSelect?: (index: number) => void;
+
+  /**
+   * Theme for the Tabs.
+   */
+  theme?: TabsTheme;
 }
 
 export const Tabs: FC<TabsProps> = ({
@@ -54,10 +59,11 @@ export const Tabs: FC<TabsProps> = ({
   direction = 'ltr',
   defaultIndex = 0,
   selectedIndex,
-  onSelect
+  onSelect,
+  theme: customTheme
 }) => {
   const id = useId();
-  const theme: TabsTheme = useComponentTheme('tabs');
+  const theme: TabsTheme = useComponentTheme('tabs', customTheme);
   const [internalActive, setInternalActive] = useState<number>(
     selectedIndex || defaultIndex
   );

--- a/src/layout/Tree/Tree.tsx
+++ b/src/layout/Tree/Tree.tsx
@@ -20,6 +20,11 @@ export interface TreeProps extends TreeContextProps {
    * Children to render inside the tree
    */
   children?: any;
+
+  /**
+   * Theme for the Tree
+   */
+  theme?: TreeTheme;
 }
 
 export const Tree: FC<TreeProps> = ({
@@ -27,9 +32,10 @@ export const Tree: FC<TreeProps> = ({
   className,
   expandedIcon,
   collapsedIcon,
+  theme: customTheme,
   ...rest
 }) => {
-  const theme: TreeTheme = useComponentTheme('tree');
+  const theme: TreeTheme = useComponentTheme('tree', customTheme);
   expandedIcon = expandedIcon ?? (
     <Arrow direction="down" className={theme.arrow} />
   );

--- a/src/layout/Tree/TreeNode.tsx
+++ b/src/layout/Tree/TreeNode.tsx
@@ -49,6 +49,11 @@ export interface TreeNodeProps {
    * Event fired when the node is collapsed
    */
   onCollapse?: () => void;
+
+  /**
+   * Theme for the Tree
+   */
+  theme?: TreeTheme;
 }
 
 export const TreeNode: FC<Partial<TreeNodeProps>> = ({
@@ -58,7 +63,8 @@ export const TreeNode: FC<Partial<TreeNodeProps>> = ({
   disabled,
   expanded: expandedProp,
   onExpand,
-  onCollapse
+  onCollapse,
+  theme: customTheme
 }) => {
   const { expandedIcon, collapsedIcon } = useContext(TreeContext);
   const [expanded, setExpanded] = useState<boolean>(expandedProp as boolean);
@@ -79,16 +85,10 @@ export const TreeNode: FC<Partial<TreeNodeProps>> = ({
     }
   }, [expanded, onCollapse, onExpand]);
 
-  const theme: TreeTheme = useComponentTheme('tree');
+  const theme: TreeTheme = useComponentTheme('tree', customTheme);
 
   return (
-    <li
-      className={twMerge(theme.node.base)}
-      // className={classNames(className, css.node, {
-      //   [css.leaf]: !hasChildren,
-      //   [css.disabled]: disabled
-      // })}
-    >
+    <li className={twMerge(theme.node.base)}>
       <div className={theme.nodeBlock}>
         {hasChildren && (
           <Button

--- a/src/layout/VerticalSpacer/VerticalSpacer.tsx
+++ b/src/layout/VerticalSpacer/VerticalSpacer.tsx
@@ -1,19 +1,28 @@
 import React, { forwardRef, HTMLAttributes } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { VerticalSpacerTheme } from './VerticalSpacerTheme';
 
 export interface VerticalSpacerProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The amount of space to add.
    */
   space: VerticalSpaceType;
+
+  /**
+   * Theme for the VerticalSpacer.
+   */
+  theme?: VerticalSpacerTheme;
 }
 
 export type VerticalSpaceType = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 
 export const VerticalSpacer = forwardRef<HTMLDivElement, VerticalSpacerProps>(
-  ({ space, className, ...rest }, ref) => {
-    const theme = useComponentTheme('verticalSpacer');
+  ({ space, className, theme: customTheme, ...rest }, ref) => {
+    const theme: VerticalSpacerTheme = useComponentTheme(
+      'verticalSpacer',
+      customTheme
+    );
 
     return (
       <div

--- a/src/typography/PageTitle/PageTitle.tsx
+++ b/src/typography/PageTitle/PageTitle.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { TypographyTheme } from '../TypographyTheme';
 
 export interface PageTitleProps
   extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -25,6 +26,11 @@ export interface PageTitleProps
    * Whether to disable the margins.
    */
   disableMargins?: boolean;
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 
 export interface PageTitleRef {
@@ -39,11 +45,12 @@ export const PageTitle: FC<PageTitleProps & PageTitleRef> = forwardRef(
       variant,
       disableMargins,
       className,
+      theme: customTheme,
       ...rest
     }: PageTitleProps,
     ref
   ) => {
-    const theme = useComponentTheme('typography');
+    const theme: TypographyTheme = useComponentTheme('typography', customTheme);
 
     return (
       <h1

--- a/src/typography/PrimaryHeading/PrimaryHeading.tsx
+++ b/src/typography/PrimaryHeading/PrimaryHeading.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { useComponentTheme } from '../../utils';
+import { TypographyTheme } from '../TypographyTheme';
 
 export interface PrimaryHeadingProps
   extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -25,6 +26,11 @@ export interface PrimaryHeadingProps
    * Whether to disable the margins.
    */
   disableMargins?: boolean;
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 export interface PrimaryHeadingRef {
   ref?: LegacyRef<HTMLHeadingElement>;
@@ -39,11 +45,15 @@ export const PrimaryHeading: FC<PrimaryHeadingProps & PrimaryHeadingRef> =
         variant,
         disableMargins,
         className,
+        theme: customTheme,
         ...rest
       }: PrimaryHeadingProps,
       ref
     ) => {
-      const theme = useComponentTheme('typography');
+      const theme: TypographyTheme = useComponentTheme(
+        'typography',
+        customTheme
+      );
 
       return (
         <h2

--- a/src/typography/SecondaryHeading/SecondaryHeading.tsx
+++ b/src/typography/SecondaryHeading/SecondaryHeading.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { TypographyTheme } from '../TypographyTheme';
 
 export interface SecondaryHeadingProps
   extends React.HTMLAttributes<HTMLHeadingElement> {
@@ -25,6 +26,11 @@ export interface SecondaryHeadingProps
    * Whether to disable the margins.
    */
   disableMargins?: boolean;
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 
 export interface SecondaryHeadingRef {
@@ -40,11 +46,15 @@ export const SecondaryHeading: FC<SecondaryHeadingProps & SecondaryHeadingRef> =
         variant,
         disableMargins,
         className,
+        theme: customTheme,
         ...rest
       }: SecondaryHeadingProps,
       ref
     ) => {
-      const theme = useComponentTheme('typography');
+      const theme: TypographyTheme = useComponentTheme(
+        'typography',
+        customTheme
+      );
 
       return (
         <h3

--- a/src/typography/SmallHeading/SmallHeading.tsx
+++ b/src/typography/SmallHeading/SmallHeading.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { TypographyTheme } from '../TypographyTheme';
 
 export type SmallHeadingColors =
   | 'default'
@@ -27,6 +28,11 @@ export interface SmallHeadingProps
    * Whether to disable the margins.
    */
   disableMargins?: boolean;
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 
 export interface SmallHeadingRef {
@@ -41,11 +47,12 @@ export const SmallHeading: FC<SmallHeadingProps & SmallHeadingRef> = forwardRef(
       variant,
       disableMargins,
       className,
+      theme: customTheme,
       ...rest
     }: SmallHeadingProps,
     ref
   ) => {
-    const theme = useComponentTheme('typography');
+    const theme: TypographyTheme = useComponentTheme('typography', customTheme);
 
     return (
       <h5

--- a/src/typography/Sub/Sub.tsx
+++ b/src/typography/Sub/Sub.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { TypographyTheme } from '../TypographyTheme';
 
 export interface SubProps extends React.HTMLAttributes<HTMLHeadingElement> {
   /**
@@ -24,6 +25,11 @@ export interface SubProps extends React.HTMLAttributes<HTMLHeadingElement> {
    * Whether to disable the margins.
    */
   disableMargins?: boolean;
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 
 export interface SubRef {
@@ -32,10 +38,18 @@ export interface SubRef {
 
 export const Sub: FC<SubProps & SubRef> = forwardRef(
   (
-    { color, variant, disableMargins, children, className, ...rest }: SubProps,
+    {
+      color,
+      variant,
+      disableMargins,
+      children,
+      className,
+      theme: customTheme,
+      ...rest
+    }: SubProps,
     ref
   ) => {
-    const theme = useComponentTheme('typography');
+    const theme: TypographyTheme = useComponentTheme('typography', customTheme);
 
     return (
       <h6

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -1,6 +1,7 @@
 import React, { FC, forwardRef, LegacyRef } from 'react';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
+import { TypographyTheme } from '../TypographyTheme';
 
 export interface TextProps extends React.HTMLAttributes<HTMLSpanElement> {
   /**
@@ -21,6 +22,11 @@ export interface TextProps extends React.HTMLAttributes<HTMLSpanElement> {
    * Font variant for the text.
    */
   variant?: 'default' | 'mono';
+
+  /**
+   * Theme for the Typography.
+   */
+  theme?: TypographyTheme;
 }
 
 export interface TextRef {
@@ -29,10 +35,18 @@ export interface TextRef {
 
 export const Text: FC<TextProps & TextRef> = forwardRef(
   (
-    { color, variant, fontStyle, children, className, ...rest }: TextProps,
+    {
+      color,
+      variant,
+      fontStyle,
+      children,
+      className,
+      theme: customTheme,
+      ...rest
+    }: TextProps,
     ref
   ) => {
-    const theme = useComponentTheme('typography');
+    const theme: TypographyTheme = useComponentTheme('typography', customTheme);
 
     return (
       <span

--- a/src/utils/Theme/hooks/useComponentTheme.ts
+++ b/src/utils/Theme/hooks/useComponentTheme.ts
@@ -2,11 +2,20 @@ import { useTheme } from './useTheme';
 import { ReablocksTheme } from '../themes';
 
 export const useComponentTheme = <T extends keyof ReablocksTheme['components']>(
-  component: T
+  component: T,
+  customTheme?: ReablocksTheme['components'][T]
 ): ReablocksTheme['components'][T] => {
-  const { theme } = useTheme();
+  const context = useTheme();
 
-  const componentTheme = theme.components[component];
+  if (customTheme) {
+    return customTheme;
+  }
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  const componentTheme = context.theme.components[component];
   if (!componentTheme) {
     throw new Error(`Component ${component} does not exist in theme`);
   }

--- a/src/utils/Theme/hooks/useTheme.ts
+++ b/src/utils/Theme/hooks/useTheme.ts
@@ -1,11 +1,11 @@
 import { useContext } from 'react';
-import { ThemeContext } from '../ThemeProvider';
+import { ThemeContext, ThemeContextProps } from '../ThemeProvider';
 
-export const useTheme = () => {
+export const useTheme = (): ThemeContextProps | null => {
   const context = useContext(ThemeContext);
 
   if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider');
+    return null;
   }
 
   return context;

--- a/src/utils/Theme/themes/extendCoponentTheme.ts
+++ b/src/utils/Theme/themes/extendCoponentTheme.ts
@@ -1,0 +1,16 @@
+import { mergeDeep } from '../helpers';
+
+type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+/**
+ * Performs a merge deep on the component theme.
+ */
+
+export const extendComponentTheme = <T extends Object>(
+  defaultTheme: T,
+  theme: DeepPartial<T>
+) => {
+  return mergeDeep(defaultTheme, theme);
+};

--- a/src/utils/Theme/themes/index.ts
+++ b/src/utils/Theme/themes/index.ts
@@ -1,3 +1,4 @@
 export * from './theme';
 export * from './extendTheme';
+export * from './extendCoponentTheme';
 export * from './extractTheme';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently to use components from lib we need to define ThemeProvide with theme.

Issue Number: N/A


## What is the new behavior?
Added theme props for each components to have ability use component with theme without ThemeProvider.
Use cases:
 - Reaviz using only one component from lib, adding ThemeProvider only for one component looks odd
- Sometimes need to have several design of the same component like (tab, chips). Theme props resolve this issue

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Example:
```
import { darkTooltipTheme, TooltipTheme, extendComponentTheme } from 'reablocks';

export const CustomTheme = () => {
  const customTheme = extendComponentTheme<TooltipTheme>(darkTooltipTheme, {
    base: 'rounded bg-green-800 text-white font-bold p-3 text-base'
  });

  return (
    <div>
      <Tooltip theme={customTheme} content="Hi there">Hover me</Tooltip>
    </div>
  );
};
```


