### PR TITLE
Fix double range in popover

### DIFF
--- a/src/form/Range/RangeDouble.tsx
+++ b/src/form/Range/RangeDouble.tsx
@@ -4,7 +4,8 @@ import React, {
   useRef,
   useState,
   FC,
-  useMemo
+  useMemo,
+  useLayoutEffect
 } from 'react';
 import { motion, useMotionValue } from 'framer-motion';
 import { RangeProps, RangeTooltip } from './RangeTooltip';
@@ -96,13 +97,20 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
     [currentMin, max, maxX, getPosition, onChange, minValueBetween]
   );
 
-  useEffect(() => {
-    const rect = range.current.getBoundingClientRect();
-    setRangeWidth(rect.width);
-    setRangeLeft(rect.left);
-    minX.set(getPosition(currentMin));
-    maxX.set(getPosition(currentMax));
-  }, [range, currentMin, minX, currentMax, maxX, getPosition]);
+  useLayoutEffect(() => {
+    const updateRange = () => {
+      const rect = range.current.getBoundingClientRect();
+      setRangeWidth(rect.width);
+      setRangeLeft(rect.left);
+      minX.set(getPosition(currentMin));
+      maxX.set(getPosition(currentMax));
+    };
+    updateRange();
+
+    // the callback inside requestAnimationFrame is ran when the browser is ready to accept the next repaint
+    // this fixes issues setting range width when the slider is placed in an animated parent element like a popup
+    requestAnimationFrame(updateRange);
+  }, [currentMin, minX, currentMax, maxX, getPosition]);
 
   useEffect(() => {
     setCurrentMin(initialMinValue);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The RangeDouble component handles are positioned incorrectly when the range is placed inside an animated parent element like a popover


## What is the new behavior?
The handles are positioned correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
BEFORE

https://github.com/reaviz/reablocks/assets/40581813/100ffa3a-a043-475a-a5d2-b682700dd2ff


AFTER


https://github.com/reaviz/reablocks/assets/40581813/ce9c31fc-44ea-4f7d-b3b3-d4904a815a9d


