### PR TITLE
Add option to show current value on sliders

### DIFF
--- a/src/form/Range/Range.story.tsx
+++ b/src/form/Range/Range.story.tsx
@@ -35,6 +35,20 @@ export const SingleDisabled = () => {
   );
 };
 
+export const SingleShowCurrentValue = () => {
+  const [state, setState] = useState<number>(20);
+  return (
+    <RangeSingle
+      onChange={setState}
+      min={10}
+      max={50}
+      value={state}
+      showValue
+      style={{ width: 250, marginTop: 30 }}
+    />
+  );
+};
+
 export const CustomFloatStep = () => {
   const [state, setState] = useState<number>(3.5);
   return (

--- a/src/form/Range/Range.story.tsx
+++ b/src/form/Range/Range.story.tsx
@@ -35,7 +35,7 @@ export const SingleDisabled = () => {
   );
 };
 
-export const SingleShowCurrentValue = () => {
+export const SingleAlwaysDisplayValue = () => {
   const [state, setState] = useState<number>(20);
   return (
     <RangeSingle
@@ -43,7 +43,7 @@ export const SingleShowCurrentValue = () => {
       min={10}
       max={50}
       value={state}
-      showValue
+      valueDisplay="always"
       style={{ width: 250, marginTop: 30 }}
     />
   );

--- a/src/form/Range/RangeDouble.tsx
+++ b/src/form/Range/RangeDouble.tsx
@@ -21,6 +21,7 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
   min,
   max,
   value,
+  showValue = false,
   onChange,
   theme: customTheme,
   step = 1
@@ -174,7 +175,11 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
             disabled={disabled}
           />
         </div>
-        <RangeTooltip visible={minTooltipVisible}>{currentMin}</RangeTooltip>
+        {showValue ? (
+          currentMin
+        ) : (
+          <RangeTooltip visible={minTooltipVisible}>{currentMin}</RangeTooltip>
+        )}
       </motion.div>
       <motion.div
         className={twMerge(theme.drag)}
@@ -213,7 +218,11 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
             disabled={disabled}
           />
         </div>
-        <RangeTooltip visible={maxTooltipVisible}>{currentMax}</RangeTooltip>
+        {showValue ? (
+          currentMax
+        ) : (
+          <RangeTooltip visible={maxTooltipVisible}>{currentMax}</RangeTooltip>
+        )}
       </motion.div>
       <div
         className={theme.rangeHighlight}

--- a/src/form/Range/RangeDouble.tsx
+++ b/src/form/Range/RangeDouble.tsx
@@ -21,7 +21,7 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
   min,
   max,
   value,
-  showValue = false,
+  valueDisplay = 'hover',
   onChange,
   theme: customTheme,
   step = 1
@@ -175,10 +175,10 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
             disabled={disabled}
           />
         </div>
-        {showValue ? (
-          currentMin
-        ) : (
+        {valueDisplay === 'hover' ? (
           <RangeTooltip visible={minTooltipVisible}>{currentMin}</RangeTooltip>
+        ) : (
+          currentMin
         )}
       </motion.div>
       <motion.div
@@ -218,10 +218,10 @@ export const RangeDouble: FC<RangeProps<[number, number]>> = ({
             disabled={disabled}
           />
         </div>
-        {showValue ? (
-          currentMax
-        ) : (
+        {valueDisplay === 'hover' ? (
           <RangeTooltip visible={maxTooltipVisible}>{currentMax}</RangeTooltip>
+        ) : (
+          currentMax
         )}
       </motion.div>
       <div

--- a/src/form/Range/RangeSingle.tsx
+++ b/src/form/Range/RangeSingle.tsx
@@ -21,6 +21,7 @@ export const RangeSingle: FC<RangeProps<number>> = ({
   min,
   max,
   value,
+  showValue = false,
   step = 1,
   theme: customTheme
 }) => {
@@ -123,7 +124,11 @@ export const RangeSingle: FC<RangeProps<number>> = ({
             onFocus={() => setFocused(true)}
           />
         </div>
-        <RangeTooltip visible={tooltipVisible}>{currentValue}</RangeTooltip>
+        {showValue ? (
+          currentValue
+        ) : (
+          <RangeTooltip visible={tooltipVisible}>{currentValue}</RangeTooltip>
+        )}
       </motion.div>
     </div>
   );

--- a/src/form/Range/RangeSingle.tsx
+++ b/src/form/Range/RangeSingle.tsx
@@ -21,7 +21,7 @@ export const RangeSingle: FC<RangeProps<number>> = ({
   min,
   max,
   value,
-  showValue = false,
+  valueDisplay = 'hover',
   step = 1,
   theme: customTheme
 }) => {
@@ -124,10 +124,10 @@ export const RangeSingle: FC<RangeProps<number>> = ({
             onFocus={() => setFocused(true)}
           />
         </div>
-        {showValue ? (
-          currentValue
-        ) : (
+        {valueDisplay === 'hover' ? (
           <RangeTooltip visible={tooltipVisible}>{currentValue}</RangeTooltip>
+        ) : (
+          currentValue
         )}
       </motion.div>
     </div>

--- a/src/form/Range/RangeTooltip.tsx
+++ b/src/form/Range/RangeTooltip.tsx
@@ -41,6 +41,12 @@ export interface RangeProps<Value> {
   value: Value;
 
   /**
+   * Whether to show the value of the range below the handle
+   * Otherwise show the value in a tooltip
+   */
+  showValue?: boolean;
+
+  /**
    * Additional css styles to apply to the range
    */
   style?: React.CSSProperties;

--- a/src/form/Range/RangeTooltip.tsx
+++ b/src/form/Range/RangeTooltip.tsx
@@ -41,10 +41,9 @@ export interface RangeProps<Value> {
   value: Value;
 
   /**
-   * Whether to show the value of the range below the handle
-   * Otherwise show the value in a tooltip
+   * When to display the current value
    */
-  showValue?: boolean;
+  valueDisplay?: 'always' | 'hover';
 
   /**
    * Additional css styles to apply to the range


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?
This adds a prop `valueDisplay` to range sliders to determine when to show the current value (always or on hover)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
![image](https://github.com/reaviz/reablocks/assets/40581813/454677d2-5c75-4bba-9cd2-7fa4840501ce)
