### PR TITLE
JSON Tree

### DIFF
--- a/docs/components/layout/JsonTree.mdx
+++ b/docs/components/layout/JsonTree.mdx
@@ -1,0 +1,26 @@
+import { Meta, Canvas, ArgTypes } from '@storybook/addon-docs';
+import { jsonTreeTheme, JsonTree, JsonTreeNode } from '../../../src/layout/Tree';
+import * as TreeStories from '../../../src/layout/Tree/JsonTree/JsonTree.story.tsx';
+import ThemeRender from '../../ThemeRender.tsx';
+
+<Meta title="Docs/Components/Layout/Json Tree" />
+
+# Json Tree
+Tree component designed for showing JSON data.
+
+## Example
+<Canvas sourceState="shown" of={TreeStories.Simple} />
+
+## Theme
+This component uses the following default theme:
+
+<ThemeRender theme={jsonTreeTheme} />
+
+Learn more about how to customize in the [Theme documentation](?path=/docs/docs-theme-getting-started--docs).
+
+## API
+### Tree
+<ArgTypes of={JsonTree} />
+
+### TreeNode
+<ArgTypes of={JsonTreeNode} />

--- a/src/layout/Collapse/Collapse.tsx
+++ b/src/layout/Collapse/Collapse.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import isFunction from 'lodash/isFunction';
 import { CollapseTheme } from './CollapseTheme';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
@@ -62,7 +61,7 @@ export const Collapse: FC<CollapseProps> = ({
           variants={VARIANTS}
           transition={TRANSITION}
         >
-          {isFunction(children) ? children() : children}
+          {typeof children === 'function' ? children() : children}
         </motion.section>
       )}
     </AnimatePresence>

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -6,16 +6,113 @@ export default {
   components: JsonTree
 };
 
-const data = {
-  name: 'John Doe',
-  age: 30,
-  over21: true,
-  children: [
-    { name: 'Jane Doe', age: 25 },
-    { name: 'Jim Doe', age: 33 }
-  ]
-};
+export const Simple = () => (
+  <JsonTree
+    data={{
+      name: 'John Doe',
+      age: 30,
+      over21: true,
+      children: [
+        { name: 'Jane Doe', age: 25 },
+        { name: 'Jim Doe', age: 33 }
+      ]
+    }}
+  />
+);
 
-export const Simple = () => <JsonTree data={data} />;
+export const Expanded = () => (
+  <JsonTree
+    data={{
+      name: 'John Doe',
+      age: 30,
+      over21: true,
+      children: [
+        { name: 'Jane Doe', age: 25 },
+        { name: 'Jim Doe', age: 33 }
+      ]
+    }}
+    expandDepth={Infinity}
+  />
+);
 
-export const Expanded = () => <JsonTree data={data} expandDepth={Infinity} />;
+export const Complex = () => (
+  <JsonTree
+    data={{
+      in_bytes: 0,
+      sensor_id: 'staging-alpha-network-sensor',
+      uid: 'a3731aac-5687-408a-8ed6-7693f360d491',
+      description: `Haxx0r ipsum mailbomb while void ssh leet deadlock over clock mega frack ack. Rsa I'm sorry Dave, I'm afraid I can't do that fopen ban eof. Recursively irc less ascii case d00dz shell emacs cd foad script kiddies gcc unix rm -rf rsa linux grep throw Leslie Lamport snarf. Lib function xss man pages packet sniffer root for continue exception ddos headers *.* protocol chown injection Dennis Ritchie thread January 1, 1970. If hack the mainframe echo race condition packet giga gurfle semaphore long python mainframe server. Tera salt cat flood false hash malloc ifdef cache port var Linus Torvalds. Daemon todo alloc new I'm compiling bar dereference memory leak crack stdio.h gnu fork highjack foo leapfrog daemon cookie. Socket ip gobble hello world system buffer ctl-c James T. Kirk segfault mountain dew client spoof loop true default wombat all your base are belong to us. Terminal overflow protected Donald Knuth float tcp big-endian. Public mutex firewall then gc null syn Trojan horse sudo machine code finally fail bin win kilo epoch regex stack trace wabbit fatal.`,
+      in_packets: 0,
+      month: 12,
+      out_ip_bytes: 48,
+      duration: 0,
+      year: 2018,
+      sensor_zone: 'default',
+      src_port: 1105,
+      uuid: 'd918540a-a152-40ab-a478-6b4cb836212d',
+      conn_state: 'S0',
+      in_ip_bytes: 0,
+      extra: {},
+      src_ips: [
+        {
+          city: null,
+          isp: null,
+          address: '192.168.242.179',
+          latitude: null,
+          org: null,
+          asn: null
+        },
+        {
+          city: 'Austin',
+          isp: 'Unassigned',
+          address: '192.168.242.179',
+          latitude: 50,
+          org: 'Unassigned',
+          asn: 50
+        },
+        {
+          city: 'New York',
+          isp: 'Unassigned',
+          address: '192.168.242.179',
+          latitude: 0,
+          org: 'Unassigned',
+          nested: [1, 2, 3]
+        }
+      ],
+      type: 'flow',
+      src_mac: '00:0c:29:30:b9:68',
+      dst_mac: '00:50:56:f0:a3:52',
+      out_packets: 1,
+      timestamp: 1544475648,
+      source_type: 'bro',
+      services: [],
+      day: 10,
+      out_bytes: 0,
+      sensor_name: 'staging-alpha-network-sensor',
+      hour: 21,
+      detections: {},
+      dst_port: 80,
+      ip_proto: 'tcp',
+      dst_ip: {
+        city: null,
+        isp: 'US Department of Defense Network',
+        region: 'Unassigned',
+        is_internal: false,
+        longitude: -97.8219985961914,
+        country_name: 'United States',
+        version: 4,
+        location: '',
+        country_code: 'US',
+        address: '6.6.6.167',
+        latitude: 37.750999450683594,
+        org: 'US Department of Defense Network',
+        asn: 0
+      },
+      history: 'S',
+      show_more: [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23
+      ]
+    }}
+  />
+);

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -134,6 +134,7 @@ export const Empties = props => (
     data={{
       in_ip_bytes: 0,
       extra: {},
+      cheese: false,
       bacon: null,
       baconer: undefined,
       arr: [

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -9,6 +9,7 @@ export default {
 const data = {
   name: 'John Doe',
   age: 30,
+  over21: true,
   children: [
     { name: 'Jane Doe', age: 25 },
     { name: 'Jim Doe', age: 33 }
@@ -16,3 +17,5 @@ const data = {
 };
 
 export const Simple = () => <JsonTree data={data} />;
+
+export const Expanded = () => <JsonTree data={data} expandDepth={Infinity} />;

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { JsonTree } from './JsonTree';
+
+export default {
+  title: 'Components/Layout/Tree/Json',
+  components: JsonTree
+};
+
+const data = {
+  name: 'John Doe',
+  age: 30,
+  children: [
+    { name: 'Jane Doe', age: 25 },
+    { name: 'Jim Doe', age: 33 }
+  ]
+};
+
+export const Simple = () => <JsonTree data={data} />;

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -3,11 +3,20 @@ import { JsonTree } from './JsonTree';
 
 export default {
   title: 'Components/Layout/Tree/Json',
-  components: JsonTree
+  components: JsonTree,
+  argTypes: {
+    showEmpty: {
+      control: 'boolean'
+    },
+    showCount: {
+      control: 'boolean'
+    }
+  }
 };
 
-export const Simple = () => (
+export const Simple = props => (
   <JsonTree
+    {...props}
     data={{
       name: 'John Doe',
       age: 30,
@@ -20,8 +29,9 @@ export const Simple = () => (
   />
 );
 
-export const Expanded = () => (
+export const Expanded = props => (
   <JsonTree
+    {...props}
     data={{
       name: 'John Doe',
       age: 30,
@@ -35,8 +45,9 @@ export const Expanded = () => (
   />
 );
 
-export const Complex = () => (
+export const Complex = props => (
   <JsonTree
+    {...props}
     data={{
       in_bytes: 0,
       sensor_id: 'staging-alpha-network-sensor',
@@ -114,5 +125,41 @@ export const Complex = () => (
         21, 22, 23
       ]
     }}
+  />
+);
+
+export const Empties = props => (
+  <JsonTree
+    {...props}
+    data={{
+      in_ip_bytes: 0,
+      extra: {},
+      bacon: null,
+      baconer: undefined,
+      arr: [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        undefined,
+        null,
+        0,
+        '',
+        Infinity,
+        NaN
+      ]
+    }}
+    expandDepth={Infinity}
   />
 );

--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -39,7 +39,10 @@ export const Expanded = props => (
       children: [
         { name: 'Jane Doe', age: 25 },
         { name: 'Jim Doe', age: 33 }
-      ]
+      ],
+      extra: {
+        key: 'value'
+      }
     }}
     expandDepth={Infinity}
   />
@@ -137,6 +140,7 @@ export const Empties = props => (
       cheese: false,
       bacon: null,
       baconer: undefined,
+      empty_string: '',
       arr: [
         1,
         2,

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -4,15 +4,54 @@ import { JsonTreeNode } from './JsonTreeNode';
 import { parseJsonTree } from './utils';
 
 export interface JsonTreeProps {
+  /**
+   * The data to be rendered as a JSON tree.
+   */
   data: { [key: string]: any };
+
+  /**
+   * If true, all nodes in the JSON tree will be expanded by default.
+   */
   showAll?: boolean;
+
+  /**
+   * The limit for the number of nodes to show when `showAll` is true.
+   */
   showAllLimit?: number;
+
+  /**
+   * The threshold for the number of nodes at which `showAll` will take effect.
+   */
   showAllThreshold?: number;
+
+  /**
+   * If true, the count of child nodes will be shown next to each node.
+   */
   showCount?: boolean;
+
+  /**
+   * If true, empty nodes will be shown in the JSON tree.
+   */
   showEmpty?: boolean;
+
+  /**
+   * If true, long text in nodes will be truncated and replaced with an ellipsis.
+   */
   ellipsisText?: boolean;
+
+  /**
+   * The maximum length of text in a node before it is truncated and replaced with an ellipsis.
+   */
   ellipsisTextLength?: number;
+
+  /**
+   * The depth at which the JSON tree nodes should be expanded by default.
+   */
   expandDepth?: number;
+
+  /**
+   * The CSS class name to be applied to the JSON tree.
+   */
   className?: string;
 }
 
@@ -20,6 +59,8 @@ export const JsonTree: FC<JsonTreeProps> = ({
   data,
   className,
   expandDepth,
+  ellipsisText,
+  ellipsisTextLength,
   ...rest
 }) => {
   const tree = parseJsonTree({ data });
@@ -32,6 +73,8 @@ export const JsonTree: FC<JsonTreeProps> = ({
           depth={1}
           data={tree}
           expandDepth={expandDepth}
+          ellipsisText={ellipsisText}
+          ellipsisTextLength={ellipsisTextLength}
         />
       </Tree>
     </div>

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react';
+import { Tree } from '../Tree';
+import { JsonTreeNode } from './JsonTreeNode';
+
+export interface JsonTreeProps {
+  data: { [key: string]: any };
+  root?: boolean;
+  allowCopy?: boolean;
+  showAll?: boolean;
+  showAllLimit?: number;
+  showAllThreshold?: number;
+  showCount: boolean;
+  showEmpty: boolean;
+  ellipsisText?: boolean;
+  ellipsisTextLength?: number;
+  expandDepth: number;
+  className?: string;
+}
+
+export const JsonTree: FC<JsonTreeProps> = ({
+  data,
+  root,
+  className,
+  ...rest
+}) => {
+  return (
+    <div tabIndex={-1}>
+      <Tree className={className} {...rest}>
+        {root && <JsonTreeNode index={0} depth={1} />}
+      </Tree>
+    </div>
+  );
+};
+
+JsonTree.defaultProps = {
+  showAll: false,
+  showAllLimit: 10,
+  showAllThreshold: 5,
+  showCount: true,
+  showEmpty: true,
+  ellipsisText: true,
+  ellipsisTextLength: 150,
+  expandDepth: 2,
+  root: true
+};

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -20,11 +20,6 @@ export interface JsonTreeProps {
   showAllLimit?: number;
 
   /**
-   * The threshold for the number of nodes at which `showAll` will take effect.
-   */
-  showAllThreshold?: number;
-
-  /**
    * If true, the count of child nodes will be shown next to each node.
    */
   showCount?: boolean;
@@ -61,6 +56,7 @@ export const JsonTree: FC<JsonTreeProps> = ({
   expandDepth,
   showEmpty,
   showCount,
+  showAllLimit,
   ellipsisText,
   ellipsisTextLength,
   ...rest
@@ -79,6 +75,7 @@ export const JsonTree: FC<JsonTreeProps> = ({
           expandDepth={expandDepth}
           ellipsisText={ellipsisText}
           ellipsisTextLength={ellipsisTextLength}
+          showAllLimit={showAllLimit}
         />
       </Tree>
     </div>

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -1,32 +1,38 @@
 import React, { FC } from 'react';
 import { Tree } from '../Tree';
 import { JsonTreeNode } from './JsonTreeNode';
+import { parseJsonTree } from './utils';
 
 export interface JsonTreeProps {
   data: { [key: string]: any };
-  root?: boolean;
-  allowCopy?: boolean;
   showAll?: boolean;
   showAllLimit?: number;
   showAllThreshold?: number;
-  showCount: boolean;
-  showEmpty: boolean;
+  showCount?: boolean;
+  showEmpty?: boolean;
   ellipsisText?: boolean;
   ellipsisTextLength?: number;
-  expandDepth: number;
+  expandDepth?: number;
   className?: string;
 }
 
 export const JsonTree: FC<JsonTreeProps> = ({
   data,
-  root,
   className,
+  expandDepth,
   ...rest
 }) => {
+  const tree = parseJsonTree({ data });
+
   return (
     <div tabIndex={-1}>
       <Tree className={className} {...rest}>
-        {root && <JsonTreeNode index={0} depth={1} />}
+        <JsonTreeNode
+          key={`node-${tree.id}`}
+          depth={1}
+          data={tree}
+          expandDepth={expandDepth}
+        />
       </Tree>
     </div>
   );
@@ -40,6 +46,5 @@ JsonTree.defaultProps = {
   showEmpty: true,
   ellipsisText: true,
   ellipsisTextLength: 150,
-  expandDepth: 2,
-  root: true
+  expandDepth: 2
 };

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -59,11 +59,13 @@ export const JsonTree: FC<JsonTreeProps> = ({
   data,
   className,
   expandDepth,
+  showEmpty,
+  showCount,
   ellipsisText,
   ellipsisTextLength,
   ...rest
 }) => {
-  const tree = parseJsonTree({ data });
+  const tree = parseJsonTree({ data, showEmpty });
 
   return (
     <div tabIndex={-1}>
@@ -72,6 +74,8 @@ export const JsonTree: FC<JsonTreeProps> = ({
           key={`node-${tree.id}`}
           depth={1}
           data={tree}
+          showEmpty={showEmpty}
+          showCount={showCount}
           expandDepth={expandDepth}
           ellipsisText={ellipsisText}
           ellipsisTextLength={ellipsisTextLength}

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -56,6 +56,7 @@ export const JsonTree: FC<JsonTreeProps> = ({
   expandDepth,
   showEmpty,
   showCount,
+  showAll,
   showAllLimit,
   ellipsisText,
   ellipsisTextLength,
@@ -75,6 +76,7 @@ export const JsonTree: FC<JsonTreeProps> = ({
           expandDepth={expandDepth}
           ellipsisText={ellipsisText}
           ellipsisTextLength={ellipsisTextLength}
+          showAll={showAll}
           showAllLimit={showAllLimit}
         />
       </Tree>
@@ -85,7 +87,6 @@ export const JsonTree: FC<JsonTreeProps> = ({
 JsonTree.defaultProps = {
   showAll: false,
   showAllLimit: 10,
-  showAllThreshold: 5,
   showCount: true,
   showEmpty: true,
   ellipsisText: true,

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -103,11 +103,9 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
 
   const renderPrimativeNode = useCallback(() => {
     const ellipsis = type === 'string' && ellipsisText;
-    const showDelimeter =
-      data.label !== null &&
-      data.label !== undefined &&
-      data.data !== null &&
-      data.data !== undefined;
+    const showDelimeter = data.label !== null && data.label !== undefined;
+    const isEmpty = data.data === null || data.data === undefined;
+    const valueLabel = showEmpty && isEmpty ? 'null' : data.data;
 
     return (
       <>
@@ -119,12 +117,12 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
           {ellipsis ? (
             <Ellipsis value={data.data} limit={ellipsisTextLength} />
           ) : (
-            data.data
+            valueLabel
           )}
         </span>
       </>
     );
-  }, [data, ellipsisText, ellipsisTextLength, theme, type]);
+  }, [data, showEmpty, ellipsisText, ellipsisTextLength, theme, type]);
 
   return (
     <TreeNode

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -4,6 +4,7 @@ import { JsonTreeData } from './utils';
 import { useComponentTheme } from '../../../utils/Theme/hooks';
 import { JsonTreeTheme } from './JsonTreeTheme';
 import { twMerge } from 'tailwind-merge';
+import { Ellipsis } from '../../../data/Ellipsis';
 
 export interface JsonTreeNodeProps {
   /**
@@ -30,6 +31,16 @@ export interface JsonTreeNodeProps {
    * Theme for the Json Tree
    */
   theme?: JsonTreeTheme;
+
+  /**
+   * If true, long text in nodes will be truncated and replaced with an ellipsis.
+   */
+  ellipsisText?: boolean;
+
+  /**
+   * The maximum length of text in a node before it is truncated and replaced with an ellipsis.
+   */
+  ellipsisTextLength?: number;
 }
 
 export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
@@ -37,6 +48,8 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
   data,
   expandDepth,
   className,
+  ellipsisText,
+  ellipsisTextLength,
   theme: customTheme
 }) => {
   const theme = useComponentTheme('jsonTree', customTheme);
@@ -49,22 +62,29 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
       <>
         <span className={twMerge(theme.node.label)}>{data.label}</span>
         <span className={twMerge(theme.node.symbol)}>{symbol}</span>
-        <span
-          className={twMerge(theme.node.count)}
-        >{`(${data.data.length.toLocaleString()} ${label})`}</span>
+        <span className={twMerge(theme.node.count)}>
+          {`(${data.data.length.toLocaleString()} ${label})`}
+        </span>
       </>
     );
-  }, [data]);
+  }, [data, theme, type]);
 
   const renderPrimativeNode = useCallback(() => {
+    const ellipsis = type === 'string' && ellipsisText;
     return (
       <>
         <span className={twMerge(theme.node.label)}>{data.label}</span>
         <span className={twMerge(theme.node.delimiter)}>:</span>
-        <span className={twMerge(theme.node.value)}>{`${data.data}`}</span>
+        <span className={twMerge(theme.node.value)}>
+          {ellipsis ? (
+            <Ellipsis value={data.data} limit={ellipsisTextLength} />
+          ) : (
+            data.data
+          )}
+        </span>
       </>
     );
-  }, [data]);
+  }, [data, ellipsisText, ellipsisTextLength, theme, type]);
 
   return (
     <TreeNode
@@ -87,6 +107,8 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
               depth={depth + 1}
               expandDepth={expandDepth}
               type={item.type}
+              ellipsisText={ellipsisText}
+              ellipsisTextLength={ellipsisTextLength}
             />
           ))}
         </>

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -1,0 +1,41 @@
+import React, { FC, PropsWithChildren, useCallback } from 'react';
+import { TreeNode } from '../TreeNode';
+
+export interface JsonTreeNodeProps extends PropsWithChildren {
+  data?: any;
+  className?: string;
+  index?: number;
+  depth?: number;
+  expandDepth?: number;
+  type?: string;
+}
+
+export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
+  depth,
+  children,
+  type,
+  expandDepth
+}) => {
+  const renderExpandableNode = useCallback(() => {
+    return <div>hi</div>;
+  }, []);
+
+  const renderPrimativeNode = useCallback(() => {
+    return <div>hi</div>;
+  }, []);
+
+  return (
+    <TreeNode
+      expanded={depth < expandDepth}
+      label={
+        <span>
+          {type === 'array' || type === 'object'
+            ? renderExpandableNode()
+            : renderPrimativeNode()}
+        </span>
+      }
+    >
+      {children}
+    </TreeNode>
+  );
+};

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -1,28 +1,39 @@
-import React, { FC, PropsWithChildren, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { TreeNode } from '../TreeNode';
+import { JsonTreeData } from './utils';
 
-export interface JsonTreeNodeProps extends PropsWithChildren {
-  data?: any;
+export interface JsonTreeNodeProps {
+  data?: JsonTreeData;
   className?: string;
-  index?: number;
   depth?: number;
   expandDepth?: number;
-  type?: string;
 }
 
 export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
   depth,
-  children,
-  type,
+  data,
   expandDepth
 }) => {
+  const type = data.type;
+
   const renderExpandableNode = useCallback(() => {
-    return <div>hi</div>;
-  }, []);
+    const label = type === 'array' ? 'items' : 'keys';
+    return (
+      <span>
+        <span className="font-mono opacity-70">{data.label}</span>
+        <span>{` (${data.data.length.toLocaleString()} ${label})`}</span>
+      </span>
+    );
+  }, [data]);
 
   const renderPrimativeNode = useCallback(() => {
-    return <div>hi</div>;
-  }, []);
+    return (
+      <span>
+        <span className="font-mono opacity-70">{data.label}</span>
+        <span>{`: ${data.data}`}</span>
+      </span>
+    );
+  }, [data]);
 
   return (
     <TreeNode
@@ -35,7 +46,19 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
         </span>
       }
     >
-      {children}
+      {(data.type === 'array' || data.type === 'object') && (
+        <>
+          {data.data.map(item => (
+            <JsonTreeNode
+              key={item.id}
+              data={item}
+              depth={depth + 1}
+              expandDepth={expandDepth}
+              type={item.type}
+            />
+          ))}
+        </>
+      )}
     </TreeNode>
   );
 };

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -1,49 +1,81 @@
 import React, { FC, useCallback } from 'react';
 import { TreeNode } from '../TreeNode';
 import { JsonTreeData } from './utils';
+import { useComponentTheme } from '../../../utils/Theme/hooks';
+import { JsonTreeTheme } from './JsonTreeTheme';
+import { twMerge } from 'tailwind-merge';
 
 export interface JsonTreeNodeProps {
+  /**
+   * The data to be rendered as a JSON tree.
+   */
   data?: JsonTreeData;
+
+  /**
+   * The CSS class name to be applied to the JSON tree node.
+   */
   className?: string;
+
+  /**
+   * The depth of the JSON tree node. This is typically used for indentation purposes.
+   */
   depth?: number;
+
+  /**
+   * The depth at which the JSON tree nodes should be expanded by default.
+   */
   expandDepth?: number;
+
+  /**
+   * Theme for the Json Tree
+   */
+  theme?: JsonTreeTheme;
 }
 
 export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
   depth,
   data,
-  expandDepth
+  expandDepth,
+  className,
+  theme: customTheme
 }) => {
+  const theme = useComponentTheme('jsonTree', customTheme);
   const type = data.type;
 
   const renderExpandableNode = useCallback(() => {
     const label = type === 'array' ? 'items' : 'keys';
+    const symbol = type === 'array' ? '[]' : '{}';
     return (
-      <span>
-        <span className="font-mono opacity-70">{data.label}</span>
-        <span>{` (${data.data.length.toLocaleString()} ${label})`}</span>
-      </span>
+      <>
+        <span className={twMerge(theme.node.label)}>{data.label}</span>
+        <span className={twMerge(theme.node.symbol)}>{symbol}</span>
+        <span
+          className={twMerge(theme.node.count)}
+        >{`(${data.data.length.toLocaleString()} ${label})`}</span>
+      </>
     );
   }, [data]);
 
   const renderPrimativeNode = useCallback(() => {
     return (
-      <span>
-        <span className="font-mono opacity-70">{data.label}</span>
-        <span>{`: ${data.data}`}</span>
-      </span>
+      <>
+        <span className={twMerge(theme.node.label)}>{data.label}</span>
+        <span className={twMerge(theme.node.delimiter)}>:</span>
+        <span className={twMerge(theme.node.value)}>{`${data.data}`}</span>
+      </>
     );
   }, [data]);
 
   return (
     <TreeNode
+      className={className}
       expanded={depth < expandDepth}
       label={
-        <span>
+        <>
           {type === 'array' || type === 'object'
             ? renderExpandableNode()
             : renderPrimativeNode()}
-        </span>
+        </>
       }
     >
       {(data.type === 'array' || data.type === 'object') && (

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -85,10 +85,18 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
 
   const renderPrimativeNode = useCallback(() => {
     const ellipsis = type === 'string' && ellipsisText;
+    const showDelimeter =
+      data.label !== null &&
+      data.label !== undefined &&
+      data.data !== null &&
+      data.data !== undefined;
+
     return (
       <>
         <span className={twMerge(theme.node.label)}>{data.label}</span>
-        <span className={twMerge(theme.node.delimiter)}>:</span>
+        {showDelimeter && (
+          <span className={twMerge(theme.node.delimiter)}>:</span>
+        )}
         <span className={twMerge(theme.node.value)}>
           {ellipsis ? (
             <Ellipsis value={data.data} limit={ellipsisTextLength} />

--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -18,6 +18,16 @@ export interface JsonTreeNodeProps {
   className?: string;
 
   /**
+   * If true, the count of child nodes will be shown next to each node.
+   */
+  showCount?: boolean;
+
+  /**
+   * If true, empty nodes will be shown in the JSON tree.
+   */
+  showEmpty?: boolean;
+
+  /**
    * The depth of the JSON tree node. This is typically used for indentation purposes.
    */
   depth?: number;
@@ -48,6 +58,8 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
   data,
   expandDepth,
   className,
+  showCount,
+  showEmpty,
   ellipsisText,
   ellipsisTextLength,
   theme: customTheme
@@ -62,12 +74,14 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
       <>
         <span className={twMerge(theme.node.label)}>{data.label}</span>
         <span className={twMerge(theme.node.symbol)}>{symbol}</span>
-        <span className={twMerge(theme.node.count)}>
-          {`(${data.data.length.toLocaleString()} ${label})`}
-        </span>
+        {showCount && (
+          <span className={twMerge(theme.node.count)}>
+            {`(${data.data.length.toLocaleString()} ${label})`}
+          </span>
+        )}
       </>
     );
-  }, [data, theme, type]);
+  }, [data, theme, type, showCount]);
 
   const renderPrimativeNode = useCallback(() => {
     const ellipsis = type === 'string' && ellipsisText;
@@ -109,6 +123,8 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
               type={item.type}
               ellipsisText={ellipsisText}
               ellipsisTextLength={ellipsisTextLength}
+              showCount={showCount}
+              showEmpty={showEmpty}
             />
           ))}
         </>

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -1,0 +1,15 @@
+export interface JsonTreeTheme {
+  node: {
+    label: string;
+    value: string;
+    count: string;
+  };
+}
+
+const baseTheme: JsonTreeTheme = {
+  node: {
+    label: 'font-mono opacity-70',
+    value: '',
+    count: ''
+  }
+};

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -2,14 +2,18 @@ export interface JsonTreeTheme {
   node: {
     label: string;
     value: string;
+    delimiter: string;
+    symbol: string;
     count: string;
   };
 }
 
-const baseTheme: JsonTreeTheme = {
+export const jsonTreeTheme: JsonTreeTheme = {
   node: {
-    label: 'font-mono opacity-70',
+    label: 'font-mono text-anakiwa',
+    delimiter: 'pr-1',
+    symbol: 'px-1 opacity-50 font-mono',
     value: '',
-    count: ''
+    count: 'opacity-50'
   }
 };

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -6,6 +6,7 @@ export interface JsonTreeTheme {
     symbol: string;
     count: string;
   };
+  pager: string;
 }
 
 export const jsonTreeTheme: JsonTreeTheme = {
@@ -15,5 +16,6 @@ export const jsonTreeTheme: JsonTreeTheme = {
     symbol: 'px-1 opacity-50 font-mono',
     value: '',
     count: 'opacity-50'
-  }
+  },
+  pager: 'opacity-50 cursor-pointer pl-4'
 };

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -1,6 +1,5 @@
 export interface JsonTreeTheme {
   node: {
-    base: string;
     label: string;
     value: string;
     delimiter: string;

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -19,3 +19,7 @@ export const jsonTreeTheme: JsonTreeTheme = {
   },
   pager: 'opacity-50 cursor-pointer pl-4'
 };
+
+export const legacyJsonTreeTheme: JsonTreeTheme = {
+  ...jsonTreeTheme
+};

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -11,7 +11,7 @@ export interface JsonTreeTheme {
 
 export const jsonTreeTheme: JsonTreeTheme = {
   node: {
-    label: 'font-mono text-anakiwa',
+    label: 'font-mono text-anakiwa light:text-blue-500',
     delimiter: 'pr-1',
     symbol: 'px-1 opacity-50 font-mono',
     value: '',

--- a/src/layout/Tree/JsonTree/JsonTreeTheme.ts
+++ b/src/layout/Tree/JsonTree/JsonTreeTheme.ts
@@ -1,5 +1,6 @@
 export interface JsonTreeTheme {
   node: {
+    base: string;
     label: string;
     value: string;
     delimiter: string;

--- a/src/layout/Tree/JsonTree/index.ts
+++ b/src/layout/Tree/JsonTree/index.ts
@@ -1,0 +1,3 @@
+export * from './JsonTree';
+export * from './JsonTreeNode';
+export * from './JsonTreeTheme';

--- a/src/layout/Tree/JsonTree/utils.ts
+++ b/src/layout/Tree/JsonTree/utils.ts
@@ -1,0 +1,102 @@
+function getDataType(data: any) {
+  if (data === null || data === undefined) {
+    return 'nil';
+  }
+
+  if (data instanceof Date) {
+    return 'date';
+  }
+
+  if (Array.isArray(data)) {
+    return 'array';
+  }
+
+  if (data != null && data.constructor.name === 'Object') {
+    return 'object';
+  }
+
+  if (typeof data === 'string') {
+    return 'string';
+  }
+
+  if (typeof data === 'number') {
+    return 'number';
+  }
+
+  if (typeof data === 'boolean') {
+    return 'boolean';
+  }
+
+  return 'unknown';
+}
+
+export interface ParseJsonInputs {
+  data: any;
+  id?: string;
+  label?: string;
+  index?: number;
+  showEmpty?: boolean;
+}
+
+export interface JsonTreeData {
+  type: string;
+  id: string;
+  data: any;
+  label: string;
+  index?: number;
+}
+
+export function parseJsonTree({
+  id = 'root',
+  data,
+  index,
+  label,
+  showEmpty = true
+}: ParseJsonInputs): JsonTreeData {
+  const type = getDataType(data);
+
+  if (type === 'object') {
+    const keys = Object.keys(data);
+    const result = keys.reduce((parsedItems, key, idx) => {
+      const value = data[key];
+      const childParsed = parseJsonTree({
+        data: value,
+        id: `${id}.${key}`,
+        index: idx,
+        label: key
+      });
+      if (showEmpty || (!showEmpty && childParsed !== null)) {
+        parsedItems.push(childParsed);
+      }
+      return parsedItems;
+    }, []);
+
+    return {
+      type,
+      id,
+      data: result,
+      label: index !== undefined ? `${index}` : 'root',
+      index
+    };
+  } else if (type === 'array') {
+    const result = data.map((item, idx) =>
+      parseJsonTree({ data: item, id: `${id}[${idx}]`, index: idx })
+    );
+
+    return {
+      type,
+      id,
+      data: result,
+      label,
+      index
+    };
+  } else {
+    return {
+      type,
+      id,
+      data,
+      label,
+      index
+    };
+  }
+}

--- a/src/layout/Tree/JsonTree/utils.ts
+++ b/src/layout/Tree/JsonTree/utils.ts
@@ -63,11 +63,14 @@ export function parseJsonTree({
         data: value,
         id: `${id}.${key}`,
         index: idx,
-        label: key
+        label: key,
+        showEmpty
       });
+
       if (showEmpty || (!showEmpty && childParsed !== null)) {
         parsedItems.push(childParsed);
       }
+
       return parsedItems;
     }, []);
 
@@ -80,7 +83,7 @@ export function parseJsonTree({
     };
   } else if (type === 'array') {
     const result = data.map((item, idx) =>
-      parseJsonTree({ data: item, id: `${id}[${idx}]`, index: idx })
+      parseJsonTree({ data: item, id: `${id}[${idx}]`, index: idx, showEmpty })
     );
 
     return {

--- a/src/layout/Tree/JsonTree/utils.ts
+++ b/src/layout/Tree/JsonTree/utils.ts
@@ -83,7 +83,12 @@ export function parseJsonTree({
     };
   } else if (type === 'array') {
     const result = data.map((item, idx) =>
-      parseJsonTree({ data: item, id: `${id}[${idx}]`, index: idx, showEmpty })
+      parseJsonTree({
+        data: item,
+        id: `${id}[${idx}]`,
+        index: idx,
+        showEmpty
+      })
     );
 
     return {

--- a/src/layout/Tree/JsonTree/utils.ts
+++ b/src/layout/Tree/JsonTree/utils.ts
@@ -74,11 +74,16 @@ export function parseJsonTree({
       return parsedItems;
     }, []);
 
+    let labelValue = index !== undefined ? `${index}` : 'root';
+    if (label !== undefined) {
+      labelValue = label;
+    }
+
     return {
       type,
       id,
       data: result,
-      label: index !== undefined ? `${index}` : 'root',
+      label: labelValue,
       index
     };
   } else if (type === 'array') {

--- a/src/layout/Tree/Tree.tsx
+++ b/src/layout/Tree/Tree.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, PropsWithChildren, useMemo } from 'react';
 import { Arrow } from '../../elements/Arrow';
 import { TreeContext, TreeContextProps } from './TreeContext';
 import { TreeTheme } from './TreeTheme';
 import { useComponentTheme } from '../../utils';
 import { twMerge } from 'tailwind-merge';
 
-export interface TreeProps extends TreeContextProps {
+export type TreeProps = {
   /**
    * CSS Classname to apply to the tree
    */
@@ -17,15 +17,11 @@ export interface TreeProps extends TreeContextProps {
   style?: React.CSSProperties;
 
   /**
-   * Children to render inside the tree
-   */
-  children?: any;
-
-  /**
    * Theme for the Tree
    */
   theme?: TreeTheme;
-}
+} & TreeContextProps &
+  PropsWithChildren;
 
 export const Tree: FC<TreeProps> = ({
   children,
@@ -36,6 +32,7 @@ export const Tree: FC<TreeProps> = ({
   ...rest
 }) => {
   const theme: TreeTheme = useComponentTheme('tree', customTheme);
+
   expandedIcon = expandedIcon ?? (
     <Arrow direction="down" className={theme.arrow} />
   );

--- a/src/layout/Tree/TreeNode.tsx
+++ b/src/layout/Tree/TreeNode.tsx
@@ -88,7 +88,7 @@ export const TreeNode: FC<Partial<TreeNodeProps>> = ({
   const theme: TreeTheme = useComponentTheme('tree', customTheme);
 
   return (
-    <li className={twMerge(theme.node.base)}>
+    <li className={twMerge(theme.node.base, className)}>
       <div className={theme.nodeBlock}>
         {hasChildren && (
           <Button

--- a/src/layout/Tree/TreeNode.tsx
+++ b/src/layout/Tree/TreeNode.tsx
@@ -64,7 +64,9 @@ export const TreeNode: FC<Partial<TreeNodeProps>> = ({
 }) => {
   const { expandedIcon, collapsedIcon } = useContext(TreeContext);
   const [expanded, setExpanded] = useState<boolean>(expandedProp as boolean);
-  const hasChildren = children && Children.count(children) > 0;
+
+  // Note: Need to use `toArray` vs `count` since it doesn't count non-rendered children
+  const hasChildren = children && Children.toArray(children).length > 0;
 
   useEffect(() => {
     setExpanded(expandedProp as boolean);

--- a/src/layout/Tree/TreeNode.tsx
+++ b/src/layout/Tree/TreeNode.tsx
@@ -5,7 +5,8 @@ import React, {
   useState,
   useEffect,
   useCallback,
-  useContext
+  useContext,
+  PropsWithChildren
 } from 'react';
 import { Button } from '../../elements/Button';
 import { Collapse } from '../Collapse';
@@ -14,7 +15,7 @@ import { twMerge } from 'tailwind-merge';
 import { TreeTheme } from './TreeTheme';
 import { useComponentTheme } from '../../utils';
 
-export interface TreeNodeProps {
+export interface TreeNodeProps extends PropsWithChildren {
   /**
    * Label to display for the node
    */
@@ -24,11 +25,6 @@ export interface TreeNodeProps {
    * CSS Classname to apply to the node
    */
   className?: string;
-
-  /**
-   * Children to render inside the node
-   */
-  children?: any;
 
   /**
    * Whether the node is expanded or not
@@ -41,6 +37,11 @@ export interface TreeNodeProps {
   disabled?: boolean;
 
   /**
+   * Theme for the Tree
+   */
+  theme?: TreeTheme;
+
+  /**
    * Event fired when the node is expanded
    */
   onExpand?: () => void;
@@ -49,11 +50,6 @@ export interface TreeNodeProps {
    * Event fired when the node is collapsed
    */
   onCollapse?: () => void;
-
-  /**
-   * Theme for the Tree
-   */
-  theme?: TreeTheme;
 }
 
 export const TreeNode: FC<Partial<TreeNodeProps>> = ({

--- a/src/layout/Tree/index.tsx
+++ b/src/layout/Tree/index.tsx
@@ -1,3 +1,4 @@
 export * from './Tree';
 export * from './TreeNode';
 export * from './TreeTheme';
+export * from './JsonTree';

--- a/src/utils/Theme/themes/theme.ts
+++ b/src/utils/Theme/themes/theme.ts
@@ -111,7 +111,8 @@ import {
   legacyTabsTheme,
   legacyDividerTheme,
   JsonTreeTheme,
-  jsonTreeTheme
+  jsonTreeTheme,
+  legacyJsonTreeTheme
 } from '../../../layout';
 
 import {
@@ -271,6 +272,7 @@ export const legacyThemeVars: ReablocksTheme = {
     tree: legacyTreeTheme,
     popover: legacyPopoverTheme,
     pager: legacyPagerTheme,
-    tabs: legacyTabsTheme
+    tabs: legacyTabsTheme,
+    jsonTree: legacyJsonTreeTheme
   }
 };

--- a/src/utils/Theme/themes/theme.ts
+++ b/src/utils/Theme/themes/theme.ts
@@ -109,7 +109,9 @@ import {
   legacyCollapseTheme,
   legacyTreeTheme,
   legacyTabsTheme,
-  legacyDividerTheme
+  legacyDividerTheme,
+  JsonTreeTheme,
+  jsonTreeTheme
 } from '../../../layout';
 
 import {
@@ -175,6 +177,7 @@ export interface ReablocksTheme {
     toggle: ToggleTheme;
     tooltip: TooltipTheme;
     tree: TreeTheme;
+    jsonTree: JsonTreeTheme;
     popover: PopoverTheme;
     pager: PagerTheme;
     tabs: TabsTheme;
@@ -222,7 +225,8 @@ export const theme: ReablocksTheme = {
     tree: treeTheme,
     popover: popoverTheme,
     pager: pagerTheme,
-    tabs: tabsTheme
+    tabs: tabsTheme,
+    jsonTree: jsonTreeTheme
   }
 };
 


### PR DESCRIPTION
This PR:

- Adds new JSON Tree
- Fixes bug in Tree where empty children still show open arrow
- Removes lodash depedency on collapse 
- Add missing `className` prop to `TreeNode`

<img width="1570" alt="image" src="https://github.com/reaviz/reablocks/assets/227909/c30633f4-aaea-411a-8b28-869604eccda9">

<img width="1570" alt="image" src="https://github.com/reaviz/reablocks/assets/227909/e390db64-ec3f-4e2c-94b9-c62503519d5c">
