### PR TITLE
update ref to be an input element

### DIFF
--- a/src/form/Input/InlineInput/InlineInput.tsx
+++ b/src/form/Input/InlineInput/InlineInput.tsx
@@ -1,6 +1,5 @@
-import React, { FC, forwardRef, RefObject, InputHTMLAttributes } from 'react';
+import { FC, forwardRef, Ref, InputHTMLAttributes } from 'react';
 import AutosizeInput from 'react-18-input-autosize';
-import { InputRef } from '../Input';
 import { twMerge } from 'tailwind-merge';
 import { InputTheme } from '../InputTheme';
 import { useComponentTheme } from '../../../utils';
@@ -46,13 +45,13 @@ export const InlineInput: FC<InlineInputProps> = forwardRef(
       theme: customTheme,
       ...rest
     },
-    ref: RefObject<InputRef>
+    ref: Ref<HTMLInputElement>
   ) => {
     const theme: InputTheme = useComponentTheme('input', customTheme);
 
     return (
       <AutosizeInput
-        inputRef={ref?.current?.inputRef}
+        inputRef={ref}
         inputClassName={twMerge(theme.inline, inputClassName)}
         placeholderIsMinWidth={placeholderIsMinWidth}
         {...rest}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #141 #154 


## What is the new behavior?
since only the inputRef is being passed through to AutosizeInput, it's unnecessary to pass the entire RefObject which is causing the type error with vitest. 

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Instead of passing an `InputRef` RefObject, just passing the `inputRef` ref portion of that object will be enough as the rest of the RefObject is not being utilized

## Other information
