### PR TITLE
Remove unused dateFormat prop

### DIFF
--- a/src/form/Calendar/Calendar.tsx
+++ b/src/form/Calendar/Calendar.tsx
@@ -70,11 +70,6 @@ export interface CalendarProps {
   previousArrow?: React.ReactNode | string;
 
   /**
-   * The date format to use for the calendar. Defaults 'MMMM yyyy'.
-   */
-  dateFormat?: string;
-
-  /**
    * Whether to display day of week labels
    */
   showDayOfWeek?: boolean;

--- a/src/form/Calendar/CalendarRange.tsx
+++ b/src/form/Calendar/CalendarRange.tsx
@@ -63,7 +63,6 @@ export const CalendarRange: FC<CalendarRangeProps> = ({
   previousYearArrow = '«',
   nextArrow = '›',
   nextYearArrow = '»',
-  dateFormat = 'MMMM yyyy',
   showDayOfWeek,
   animated = true,
   onChange,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[x] Yes (technically I guess?)
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This props not getting used anywhere,  and there's no date's being displayed in the calendar to use it on

date in this story's being displayed outside Calendar
<img width="1096" alt="Screenshot 2024-05-09 at 10 41 46 AM" src="https://github.com/reaviz/reablocks/assets/40581813/db1e6815-9632-461b-99b3-d2213eed581f">
