### PR TITLE
add ability to style states of disabled toggle

### DIFF
--- a/src/form/Toggle/Toggle.story.tsx
+++ b/src/form/Toggle/Toggle.story.tsx
@@ -11,10 +11,13 @@ export const Simple = () => {
   return <Toggle checked={state} onChange={setState} />;
 };
 
-export const Disabled = () => {
-  const [state, setState] = useState(true);
-  return <Toggle disabled checked={state} onChange={setState} />;
-};
+export const Disabled = () => (
+  <>
+    <Toggle disabled checked={false} />
+    <br />
+    <Toggle disabled checked />
+  </>
+);
 
 export const Sizes = () => {
   const [stateSmall, setStateSmall] = useState(true);

--- a/src/form/Toggle/Toggle.story.tsx
+++ b/src/form/Toggle/Toggle.story.tsx
@@ -1,5 +1,5 @@
-import { Toggle } from './Toggle';
 import React, { useState } from 'react';
+import { Toggle } from './Toggle';
 
 export default {
   title: 'Components/Form/Toggle',

--- a/src/form/Toggle/Toggle.tsx
+++ b/src/form/Toggle/Toggle.tsx
@@ -74,7 +74,8 @@ export const Toggle: FC<ToggleProps & ToggleRef> = forwardRef<
         tabIndex={0}
         className={twMerge(
           theme.base,
-          disabled && theme.disabled,
+          disabled && theme.disabled.base,
+          disabled && checked && theme.disabled.checked,
           checked && theme.checked,
           theme.sizes[size],
           className

--- a/src/form/Toggle/Toggle.tsx
+++ b/src/form/Toggle/Toggle.tsx
@@ -74,8 +74,7 @@ export const Toggle: FC<ToggleProps & ToggleRef> = forwardRef<
         tabIndex={0}
         className={twMerge(
           theme.base,
-          disabled && theme.disabled.base,
-          disabled && checked && theme.disabled.checked,
+          disabled && theme.disabled,
           checked && theme.checked,
           theme.sizes[size],
           className
@@ -93,7 +92,12 @@ export const Toggle: FC<ToggleProps & ToggleRef> = forwardRef<
         }}
       >
         <motion.div
-          className={twMerge(theme.handle.base, theme.handle.sizes[size])}
+          className={twMerge(
+            theme.handle.base,
+            theme.handle.sizes[size],
+            disabled && theme.handle.disabled,
+            checked && theme.handle.checked
+          )}
           layout
           transition={{
             type: 'spring',

--- a/src/form/Toggle/ToggleTheme.ts
+++ b/src/form/Toggle/ToggleTheme.ts
@@ -1,9 +1,11 @@
 export interface ToggleTheme {
   base: string;
-  disabled: { base: string; checked: string };
+  disabled: string;
   checked: string;
   handle: {
     base: string;
+    disabled: string;
+    checked: string;
     sizes: {
       small: string;
       medium: string;
@@ -19,10 +21,12 @@ export interface ToggleTheme {
 
 const baseTheme: ToggleTheme = {
   base: 'flex items-center justify-start cursor-pointer bg-surface box-border border border-panel-accent rounded-full',
-  disabled: { base: 'cursor-not-allowed opacity-60', checked: '' },
-  checked: 'justify-end bg-primary',
+  disabled: 'cursor-not-allowed opacity-60',
+  checked: 'checked justify-end bg-primary',
   handle: {
     base: 'rounded-full bg-panel',
+    disabled: '',
+    checked: 'checked',
     sizes: {
       small: 'w-3 h-full',
       medium: 'w-5 h-full',
@@ -44,13 +48,10 @@ export const legacyToggleTheme: ToggleTheme = {
     baseTheme.base,
     'bg-[var(--toggle-background)] rounded-[var(--toggle-border-radius)] [border:_var(--toggle-border)]'
   ].join(' '),
-  disabled: {
-    base: [
-      baseTheme.disabled,
-      'opacity-[var(--toggle-disabled-opacity,0.8)] bg-[var(--toggle-disabled-background)]'
-    ].join(' '),
-    checked: ''
-  },
+  disabled: [
+    baseTheme.disabled,
+    'opacity-[var(--toggle-disabled-opacity,0.8)] bg-[var(--toggle-disabled-background)]'
+  ].join(' '),
   checked: [
     baseTheme.checked,
     'bg-[var(--toggle-background-checked)] [border:_var(--toggle-border-checked)]'
@@ -69,6 +70,8 @@ export const legacyToggleTheme: ToggleTheme = {
       baseTheme.handle.base,
       'bg-[var(--toggle-handle-background)] rounded-[var(--toggle-handle-border-radius)]'
     ].join(' '),
+    disabled: '',
+    checked: '',
     sizes: {
       small:
         'h-[calc(var(--toggle-handle-size,25px)_/_2)] w-[calc(var(--toggle-handle-size,25px)_/_2)]',

--- a/src/form/Toggle/ToggleTheme.ts
+++ b/src/form/Toggle/ToggleTheme.ts
@@ -1,6 +1,6 @@
 export interface ToggleTheme {
   base: string;
-  disabled: string;
+  disabled: { base: string; checked: string };
   checked: string;
   handle: {
     base: string;
@@ -19,7 +19,7 @@ export interface ToggleTheme {
 
 const baseTheme: ToggleTheme = {
   base: 'flex items-center justify-start cursor-pointer bg-surface box-border border border-panel-accent rounded-full',
-  disabled: 'cursor-not-allowed opacity-60',
+  disabled: { base: 'cursor-not-allowed opacity-60', checked: '' },
   checked: 'justify-end bg-primary',
   handle: {
     base: 'rounded-full bg-panel',
@@ -44,10 +44,13 @@ export const legacyToggleTheme: ToggleTheme = {
     baseTheme.base,
     'bg-[var(--toggle-background)] rounded-[var(--toggle-border-radius)] [border:_var(--toggle-border)]'
   ].join(' '),
-  disabled: [
-    baseTheme.disabled,
-    'opacity-[var(--toggle-disabled-opacity,0.8)] bg-[var(--toggle-disabled-background)]'
-  ].join(' '),
+  disabled: {
+    base: [
+      baseTheme.disabled,
+      'opacity-[var(--toggle-disabled-opacity,0.8)] bg-[var(--toggle-disabled-background)]'
+    ].join(' '),
+    checked: ''
+  },
   checked: [
     baseTheme.checked,
     'bg-[var(--toggle-background-checked)] [border:_var(--toggle-border-checked)]'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Disabled state for Toggle only had one class

## What is the new behavior?
Disabled state for Toggle can now be separated into `base` (toggle is off) and `checked` states

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Also updated the Toggle disabled story to include both states of disabled Toggles