### PR TITLE
Add ability to extend colors in component themes

### DIFF
--- a/src/elements/Badge/Badge.tsx
+++ b/src/elements/Badge/Badge.tsx
@@ -22,7 +22,7 @@ export interface BadgeProps
   /**
    * The color of the badge.
    */
-  color?: BadgeColor;
+  color?: BadgeColor | string;
 
   /**
    * Whether to disable the margins.

--- a/src/elements/Badge/BadgeTheme.ts
+++ b/src/elements/Badge/BadgeTheme.ts
@@ -8,6 +8,7 @@ export interface BadgeTheme {
     primary: string;
     secondary: string;
     error: string;
+    [key: string]: string;
   };
   positions: {
     'top-start': string;

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -13,7 +13,14 @@ export interface ButtonProps
   /**
    * Color variation of the button.
    */
-  color?: 'default' | 'primary' | 'secondary' | 'error' | 'success' | 'warning';
+  color?:
+    | 'default'
+    | 'primary'
+    | 'secondary'
+    | 'error'
+    | 'success'
+    | 'warning'
+    | string;
 
   /**
    * Style variant of the button.

--- a/src/elements/Button/ButtonTheme.ts
+++ b/src/elements/Button/ButtonTheme.ts
@@ -50,6 +50,11 @@ export interface ButtonTheme {
       outline: string;
       text: string;
     };
+    [key: string]: {
+      filled: string;
+      outline: string;
+      text: string;
+    };
   };
   sizes: {
     small: string;

--- a/src/elements/Chip/Chip.tsx
+++ b/src/elements/Chip/Chip.tsx
@@ -14,7 +14,8 @@ export interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   /**
    * Size variant for the chip.

--- a/src/elements/Chip/ChipTheme.ts
+++ b/src/elements/Chip/ChipTheme.ts
@@ -5,7 +5,7 @@ interface ThemeColor {
     outline?: string;
   };
   selectable?: {
-    base: string;
+    base?: string;
     variants?: {
       filled?: {
         base?: string;
@@ -36,13 +36,14 @@ export interface ChipTheme {
     outline: string;
   };
   colors: {
-    default: ThemeColor;
+    default?: ThemeColor;
     primary?: ThemeColor;
     secondary?: ThemeColor;
     success?: ThemeColor;
     warning?: ThemeColor;
     error?: ThemeColor;
     info?: ThemeColor;
+    [key: string]: ThemeColor;
   };
   sizes: {
     small: string;

--- a/src/typography/PageTitle/PageTitle.tsx
+++ b/src/typography/PageTitle/PageTitle.tsx
@@ -15,7 +15,8 @@ export interface PageTitleProps
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   /**
    * Font variant for the title.

--- a/src/typography/PrimaryHeading/PrimaryHeading.tsx
+++ b/src/typography/PrimaryHeading/PrimaryHeading.tsx
@@ -15,7 +15,8 @@ export interface PrimaryHeadingProps
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   /**
    * Font variant for the heading.

--- a/src/typography/SecondaryHeading/SecondaryHeading.tsx
+++ b/src/typography/SecondaryHeading/SecondaryHeading.tsx
@@ -15,7 +15,8 @@ export interface SecondaryHeadingProps
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   /**
    * Font variant for the heading.

--- a/src/typography/SmallHeading/SmallHeading.tsx
+++ b/src/typography/SmallHeading/SmallHeading.tsx
@@ -10,7 +10,8 @@ export type SmallHeadingColors =
   | 'error'
   | 'success'
   | 'warning'
-  | 'info';
+  | 'info'
+  | string;
 
 export interface SmallHeadingProps
   extends React.HTMLAttributes<HTMLHeadingElement> {

--- a/src/typography/Sub/Sub.tsx
+++ b/src/typography/Sub/Sub.tsx
@@ -14,7 +14,8 @@ export interface SubProps extends React.HTMLAttributes<HTMLHeadingElement> {
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   /**
    * Font variant for the text.

--- a/src/typography/Text/Text.tsx
+++ b/src/typography/Text/Text.tsx
@@ -14,7 +14,8 @@ export interface TextProps extends React.HTMLAttributes<HTMLSpanElement> {
     | 'error'
     | 'success'
     | 'warning'
-    | 'info';
+    | 'info'
+    | string;
 
   fontStyle?: 'default' | 'thin' | 'bold' | 'extraBold' | 'italic';
 

--- a/src/typography/TypographyTheme.ts
+++ b/src/typography/TypographyTheme.ts
@@ -17,6 +17,7 @@ export interface TypographyTheme {
     warning: string;
     error: string;
     info: string;
+    [key: string]: string;
   };
   sub: string;
   smallHeading: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) - I'm gonna update docs in `reablocks-website` repo

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It's not easy to add colors to Buttons, Chips, etc. that aren't already included in the theme without ignoring ts


## What is the new behavior?
You can add any color to multiple component themes and pass any color as a prop

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Here's an example of easily adding `pink` as a `Chip` color

```
const customTheme = extendComponentTheme<ChipTheme>(chipTheme, {
  base: `${chipTheme.base} rounded-full`,
  colors: {
    pink: {
      variants: {
        filled: `${chipTheme?.colors?.pink?.variants?.filled} text-panel-content bg-pink-500/10 border-pink-500`
      }
    }
  }
});

export const Simple = () => (
  <DeletableChip
    color="pink"
    theme={customTheme}
    onDelete={() => console.log('on delete')}
  >
    Deletable
  </DeletableChip>
);
```
<img width="227" alt="image" src="https://github.com/reaviz/reablocks/assets/40581813/c9d7f0b5-ffd6-441e-b55c-6743f0bba915">

