### PR TITLE
Add root rendering option to JsonTree

### DIFF
--- a/src/layout/Tree/JsonTree/JsonTree.story.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.story.tsx
@@ -168,3 +168,19 @@ export const Empties = props => (
     expandDepth={Infinity}
   />
 );
+
+export const NoRoot = props => (
+  <JsonTree
+    {...props}
+    data={{
+      name: 'John Doe',
+      age: 30,
+      over21: true,
+      children: [
+        { name: 'Jane Doe', age: 25 },
+        { name: 'Jim Doe', age: 33 }
+      ]
+    }}
+    root={false}
+  />
+);

--- a/src/layout/Tree/JsonTree/JsonTree.tsx
+++ b/src/layout/Tree/JsonTree/JsonTree.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { Tree } from '@/layout/Tree/Tree';
 import { JsonTreeNode } from './JsonTreeNode';
 import { parseJsonTree } from './utils';
@@ -45,6 +45,11 @@ export interface JsonTreeProps {
   expandDepth?: number;
 
   /**
+   * If true, the JSON tree will be rendered with a root node.
+   */
+  root?: boolean;
+
+  /**
    * The CSS class name to be applied to the JSON tree.
    */
   className?: string;
@@ -60,6 +65,7 @@ export const JsonTree: FC<JsonTreeProps> = ({
   showAllLimit = 10,
   ellipsisText = true,
   ellipsisTextLength = 150,
+  root = true,
   ...rest
 }) => {
   const tree = parseJsonTree({ data, showEmpty });
@@ -67,18 +73,35 @@ export const JsonTree: FC<JsonTreeProps> = ({
   return (
     <div tabIndex={-1}>
       <Tree className={className} {...rest}>
-        <JsonTreeNode
-          key={`node-${tree.id}`}
-          depth={1}
-          data={tree}
-          showEmpty={showEmpty}
-          showCount={showCount}
-          expandDepth={expandDepth}
-          ellipsisText={ellipsisText}
-          ellipsisTextLength={ellipsisTextLength}
-          showAll={showAll}
-          showAllLimit={showAllLimit}
-        />
+        {root && (
+          <JsonTreeNode
+            key={`node-${tree.id}`}
+            depth={1}
+            data={tree}
+            showEmpty={showEmpty}
+            showCount={showCount}
+            expandDepth={expandDepth}
+            ellipsisText={ellipsisText}
+            ellipsisTextLength={ellipsisTextLength}
+            showAll={showAll}
+            showAllLimit={showAllLimit}
+          />
+        )}
+        {!root &&
+          tree?.data?.map(item => (
+            <JsonTreeNode
+              key={`node-${item.id}`}
+              depth={1}
+              data={item}
+              showEmpty={showEmpty}
+              showCount={showCount}
+              expandDepth={expandDepth}
+              ellipsisText={ellipsisText}
+              ellipsisTextLength={ellipsisTextLength}
+              showAll={showAll}
+              showAllLimit={showAllLimit}
+            />
+          ))}
       </Tree>
     </div>
   );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The root node is always rendered in the JsonTree component


## What is the new behavior?
You can control whether the root node is rendered using the `root` prop

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


https://github.com/reaviz/reablocks/assets/40581813/192e8841-9db5-406f-8ce9-7225bf90bd45


