### PR TITLE
Fix checking "is the day in range"

### DIFF
--- a/src/form/Calendar/Calendar.story.tsx
+++ b/src/form/Calendar/Calendar.story.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card } from '../../layout/Card';
 import { Calendar } from './Calendar';
 import { CalendarRange } from './CalendarRange';
-import { add, addMonths, sub } from 'date-fns';
+import { add, addMonths, endOfMonth, startOfMonth, sub } from 'date-fns';
 import { Divider } from '../../layout/Divider';
 import { Stack } from '../../layout/Stack';
 
@@ -132,6 +132,31 @@ export const WithLabels = () => {
 
 export const Range = () => {
   const [range, setRange] = useState<[Date, Date]>();
+
+  return (
+    <Card>
+      <Calendar
+        value={range}
+        onChange={val => setRange(val as [Date, Date | undefined])}
+        isRange
+        showDayOfWeek
+        showToday
+      />
+      <Divider />
+      <Stack justifyContent="center">
+        {range
+          ? `${range[0]?.toLocaleDateString()}-${range[1]?.toLocaleDateString()}`
+          : 'No date selected'}
+      </Stack>
+    </Card>
+  );
+};
+
+export const CurrentMonth = () => {
+  const [range, setRange] = useState<[Date, Date]>([
+    startOfMonth(new Date()),
+    endOfMonth(new Date())
+  ]);
 
   return (
     <Card>

--- a/src/form/Calendar/utils.ts
+++ b/src/form/Calendar/utils.ts
@@ -13,7 +13,8 @@ import {
   startOfMonth,
   min,
   max,
-  subDays
+  subDays,
+  isWithinInterval
 } from 'date-fns';
 
 /**
@@ -155,10 +156,7 @@ export function getDayAttributes(
     const startDate = min(range);
     const endDate = max(range);
 
-    return (
-      isAfter(date, addDays(startDate, -1)) &&
-      isBefore(date, addDays(endDate, 1))
-    );
+    return isWithinInterval(date, { start: startDate, end: endDate });
   };
 
   const isSelectionStarted = Array.isArray(current) && isValid(current[0]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When end date of range end of the day (Wed Jul 31 2024 23:59:59) calendar highlight the next day which should not be highlighted
![Screenshot 2024-07-04 at 12 09 39](https://github.com/reaviz/reablocks/assets/5399389/e7223dba-441b-4aad-a818-0d3f8c4bbc5c)


## What is the new behavior?
![Screenshot 2024-07-04 at 12 10 32](https://github.com/reaviz/reablocks/assets/5399389/07378bc1-b93a-40df-ba5f-e3169b6ae9ca)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
