### PR TITLE
add abilty to control icon button sizes independent of button size

### DIFF
--- a/src/elements/Button/ButtonTheme.ts
+++ b/src/elements/Button/ButtonTheme.ts
@@ -71,6 +71,12 @@ export interface ButtonTheme {
     large: string;
     [key: string]: string;
   };
+  iconSizes: {
+    small: string;
+    medium: string;
+    large: string;
+    [key: string]: string;
+  };
 }
 
 const baseTheme: Partial<ButtonTheme> = {
@@ -95,6 +101,11 @@ const baseTheme: Partial<ButtonTheme> = {
     small: 'text-sm px-2 py-1 leading-[normal]',
     medium: 'text-base px-4 py-2 leading-[normal]',
     large: 'text-xl px-5 py-2.5 leading-[normal]'
+  },
+  iconSizes: {
+    small: 'px-2 py-1',
+    medium: 'px-4 py-2',
+    large: 'px-5 py-2.5'
   }
 };
 
@@ -109,6 +120,7 @@ export const buttonTheme: ButtonTheme = {
   groupText: baseTheme.groupText,
   adornment: baseTheme.adornment,
   sizes: baseTheme.sizes,
+  iconSizes: baseTheme.iconSizes,
   variants: {
     filled:
       'bg-secondary hover:bg-border-secondary-hover border-secondary light:text-gray-100',
@@ -165,6 +177,11 @@ export const legacyButtonTheme: ButtonTheme = {
   group: baseTheme.group,
   groupText: baseTheme.groupText,
   sizes: {
+    small: '[font-size:_var(--font-size-sm)] p-[var(--button-spacing-sm)]',
+    medium: '[font-size:_var(--font-size-md)] p-[var(--button-spacing-md)]',
+    large: '[font-size:_var(--font-size-lg)] p-[var(--button-spacing-lg)]'
+  },
+  iconSizes: {
     small: '[font-size:_var(--font-size-sm)] p-[var(--button-spacing-sm)]',
     medium: '[font-size:_var(--font-size-md)] p-[var(--button-spacing-md)]',
     large: '[font-size:_var(--font-size-lg)] p-[var(--button-spacing-lg)]'

--- a/src/elements/IconButton/IconButton.story.tsx
+++ b/src/elements/IconButton/IconButton.story.tsx
@@ -1,5 +1,11 @@
 import { IconButton } from './IconButton';
 import { Stack } from '../../layout';
+import {
+  extendTheme,
+  PartialReablocksTheme
+} from '../../utils/Theme/themes/extendTheme';
+import { ThemeProvider } from '../../utils/Theme/ThemeProvider';
+import { theme } from '../../utils/Theme/themes/theme';
 
 export default {
   title: 'Components/Elements/IconButton',
@@ -123,3 +129,32 @@ export const Variants = () => (
     </IconButton>
   </div>
 );
+
+export const Square = () => {
+  const iconTheme: PartialReablocksTheme = {
+    components: {
+      button: {
+        iconSizes: {
+          small: 'p-1',
+          medium: 'p-2',
+          large: 'p-2.5'
+        }
+      }
+    }
+  };
+  return (
+    <ThemeProvider theme={extendTheme(theme, iconTheme)}>
+      <Stack>
+        <IconButton size="small">
+          <BellIcon />
+        </IconButton>
+        <IconButton size="medium">
+          <BellIcon />
+        </IconButton>
+        <IconButton size="large">
+          <BellIcon />
+        </IconButton>
+      </Stack>
+    </ThemeProvider>
+  );
+};

--- a/src/elements/IconButton/IconButton.tsx
+++ b/src/elements/IconButton/IconButton.tsx
@@ -1,13 +1,33 @@
 import React, { FC, forwardRef, Ref } from 'react';
 import { Button, ButtonProps, ButtonRef } from '@/elements/Button';
+import { twMerge } from 'tailwind-merge';
+import { useComponentTheme } from '@/utils';
 
 export interface IconButtonProps
   extends Omit<ButtonProps, 'fullWidth' | 'startAdornment' | 'endAdornment'> {}
 
 export const IconButton: FC<IconButtonProps & ButtonRef> = forwardRef(
-  ({ children, ...rest }: IconButtonProps, ref: Ref<HTMLButtonElement>) => (
-    <Button {...rest} ref={ref}>
-      {children}
-    </Button>
-  )
+  (
+    {
+      children,
+      className,
+      size = 'medium',
+      theme: customTheme,
+      ...rest
+    }: IconButtonProps,
+    ref: Ref<HTMLButtonElement>
+  ) => {
+    const theme = useComponentTheme('button', customTheme);
+
+    return (
+      <Button
+        className={twMerge(theme.iconSizes[size], className)}
+        size={size}
+        {...rest}
+        ref={ref}
+      >
+        {children}
+      </Button>
+    );
+  }
 );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, if we set buttons to have unequal x and y padding, you would have to always add styles (or a custom size) to icon buttons if you wanted to make to square.

Issue Number: N/A


## What is the new behavior?

Since we have an independent `<IconButton />` component, we should allow for the icon button size to be controlled independently. This PR adds theme to allow control of icon button sizes independently of regular button sizes.

Also added a new story to demonstrate:
![image](https://github.com/user-attachments/assets/3123bd78-7cfd-4556-97a0-f68954f51171)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No - setting default icon button size padding to be the same as default button padding
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Docs update - https://github.com/reaviz/reablocks-website/pull/35