### PR TITLE
Fix json tree node alignment

### DIFF
--- a/src/layout/Tree/JsonTree/JsonTreeNode.tsx
+++ b/src/layout/Tree/JsonTree/JsonTreeNode.tsx
@@ -134,7 +134,11 @@ export const JsonTreeNode: FC<JsonTreeNodeProps> = ({
         )}
         <span className={twMerge(theme.node.value)}>
           {ellipsis && !isEmptyString ? (
-            <Ellipsis value={data.data} limit={ellipsisTextLength} />
+            <Ellipsis
+              value={data.data}
+              limit={ellipsisTextLength}
+              className="inline"
+            />
           ) : (
             valueLabel
           )}


### PR DESCRIPTION
The issue was causing by changing `span` -> `div` for Ellipsis component

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Before:
![Screenshot 2024-09-11 at 09 44 31](https://github.com/user-attachments/assets/b7348a05-9bc8-4e68-ac16-8a9238162136)

After:
![Screenshot 2024-09-11 at 09 44 40](https://github.com/user-attachments/assets/9ed2854b-54c4-41f4-9c9c-0442d261f0f4)



## Other information
