### PR TITLE
feat: add show on single page prop to Pager

### DIFF
--- a/src/data/Pager/Pager.tsx
+++ b/src/data/Pager/Pager.tsx
@@ -79,15 +79,6 @@ export interface PagerProps {
   displayMode?: 'pages' | 'items' | 'all';
 
   /**
-   * Determines whether content should be shown when there is only a single page.
-   *
-   * @type {boolean}
-   * @default true
-   * @optional
-   */
-  hideOnSinglePage?: boolean;
-
-  /**
    * The theme for the Pager.
    */
   theme?: PagerTheme;
@@ -107,7 +98,6 @@ export const Pager: FC<PagerProps> = ({
   nextArrow = <NextArrow />,
   onPageChange,
   displayMode = 'pages',
-  hideOnSinglePage = true,
   theme: customTheme
 }) => {
   const pageCount = Math.ceil(total / size);
@@ -132,10 +122,6 @@ export const Pager: FC<PagerProps> = ({
       onPageChange?.(pageCount - 1);
     }
   }, [canNext, page, onPageChange, pageCount]);
-
-  if (hideOnSinglePage && pageCount === 1) {
-    return null;
-  }
 
   return (
     <div className={twMerge(theme.base, className)}>

--- a/src/data/Pager/Pager.tsx
+++ b/src/data/Pager/Pager.tsx
@@ -79,6 +79,15 @@ export interface PagerProps {
   displayMode?: 'pages' | 'items' | 'all';
 
   /**
+   * Determines whether content should be shown when there is only a single page.
+   *
+   * @type {boolean}
+   * @default true
+   * @optional
+   */
+  hideOnSinglePage?: boolean;
+
+  /**
    * The theme for the Pager.
    */
   theme?: PagerTheme;
@@ -98,6 +107,7 @@ export const Pager: FC<PagerProps> = ({
   nextArrow = <NextArrow />,
   onPageChange,
   displayMode = 'pages',
+  hideOnSinglePage = true,
   theme: customTheme
 }) => {
   const pageCount = Math.ceil(total / size);
@@ -123,7 +133,7 @@ export const Pager: FC<PagerProps> = ({
     }
   }, [canNext, page, onPageChange, pageCount]);
 
-  if (pageCount === 1) {
+  if (hideOnSinglePage && pageCount === 1) {
     return null;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when pageCount === 1, the content is always hidden. There is no option to override this behavior.

Issue Number: N/A


## What is the new behavior?
A new optional boolean flag showOnSinglePage has been introduced. When set to true, shows the pager even if there is only one page. If defaults to false and keeps the existing behavior in tact.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
## Other information


I did not include it in this pr, but I used the following storybook story to easily test the changes. You just need to set total to 10 and set `hideOnSinglePage` to `false` via the controls.

```
export const Default = ({ page = 0, size = 10, total = 100, ...rest }) => {
  return <Pager page={page} size={size} total={total} {...rest} />;
};
```