### PR TITLE
Fix syntax errors in class names that cause an error when using prebuild styles without tailwind

### DIFF
--- a/src/elements/Kbd/KbdTheme.ts
+++ b/src/elements/Kbd/KbdTheme.ts
@@ -14,7 +14,7 @@ export const kbdTheme: KbdTheme = {
 
 export const legacyKbdTheme: KbdTheme = {
   ...baseTheme,
-  base: [baseTheme.base, 'gap-[var(--spacing-sm);]'].join(' '),
+  base: [baseTheme.base, 'gap-[var(--spacing-sm)]'].join(' '),
   chip: [
     baseTheme.chip,
     'rounded-[var(--border-radius-sm)] [font-family:_var(--mono-font-family)]'

--- a/src/form/Toggle/ToggleTheme.ts
+++ b/src/form/Toggle/ToggleTheme.ts
@@ -63,9 +63,9 @@ export const legacyToggleTheme: ToggleTheme = {
   ].join(' '),
   sizes: {
     small:
-      'h-[calc(var(--toggle-height,35px)_/_2)] w-[calc(var(--toggle-width,55px)_/_2)] pt-[calc(var(--toggle-spacing)] pb-[2)] px-[/]',
+      'h-[calc(var(--toggle-height,35px)_/_2)] w-[calc(var(--toggle-width,55px)_/_2)] pt-[calc(var(--toggle-spacing)] pb-[2)]',
     medium:
-      'h-[calc(var(--toggle-height,35px)_/_1.5)] w-[calc(var(--toggle-width,55px)_/_1.5)] pt-[calc(var(--toggle-spacing)] pb-[1.5)] px-[/]',
+      'h-[calc(var(--toggle-height,35px)_/_1.5)] w-[calc(var(--toggle-width,55px)_/_1.5)] pt-[calc(var(--toggle-spacing)] pb-[1.5)]',
     large:
       'h-[var(--toggle-height,35px)] w-[var(--toggle-width,55px)] pt-[var(--toggle-spacing)] pr-[var(--toggle-spacing)] pb-[var(--toggle-spacing)] pl-[var(--toggle-spacing)]'
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
These syntax errors cause an error when using CSS without tailwind

Issue Number: N/A


## What is the new behavior?
The fix will allow using reablocks prebuilt styles without a tailwind (default style without override)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
An error when using `@import "../node_modules/reablocks/dist/index.css";` instead `@source "../node_modules/reablocks";`
![Screenshot 2025-04-07 at 16 12 26](https://github.com/user-attachments/assets/46147ae7-3526-4676-a966-f40041a11e91)


