### PR TITLE
Tooltip arrrows support

### DIFF
--- a/src/layers/Tooltip/Tooltip.story.tsx
+++ b/src/layers/Tooltip/Tooltip.story.tsx
@@ -161,17 +161,49 @@ export const WithArrow = () => (
       color: 'green'
     }}
   >
-    <Tooltip content="Top" placement="top" showArrow>
+    <Tooltip content="Top" placement="top" arrow>
       Top
     </Tooltip>
-    <Tooltip content="Bottom" placement="bottom" showArrow>
+    <Tooltip content="Bottom" placement="bottom" arrow>
       Bottom
     </Tooltip>
-    <Tooltip content="Left" placement="left" showArrow>
+    <Tooltip content="Left" placement="left" arrow>
       Left
     </Tooltip>
-    <Tooltip content="Right" placement="right" showArrow>
+    <Tooltip content="Right" placement="right" arrow>
       Right
+    </Tooltip>
+  </div>
+);
+
+export const WithCustomArrow = () => (
+  <div
+    style={{
+      display: 'flex',
+      gap: 40,
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      margin: '80px auto',
+      color: 'green'
+    }}
+  >
+    <Tooltip
+      content="Custom"
+      placement="top"
+      arrow={
+        <span
+          style={{
+            display: 'block',
+            width: 12,
+            height: 12,
+            background: 'var(--panel-accent)',
+            transform: 'rotate(45deg)'
+          }}
+        />
+      }
+    >
+      Custom arrow
     </Tooltip>
   </div>
 );

--- a/src/layers/Tooltip/Tooltip.story.tsx
+++ b/src/layers/Tooltip/Tooltip.story.tsx
@@ -149,6 +149,33 @@ export const FollowScroll = () => (
   </div>
 );
 
+export const WithArrow = () => (
+  <div
+    style={{
+      display: 'flex',
+      gap: 40,
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      margin: '80px auto',
+      color: 'green'
+    }}
+  >
+    <Tooltip content="Top" placement="top" showArrow>
+      Top
+    </Tooltip>
+    <Tooltip content="Bottom" placement="bottom" showArrow>
+      Bottom
+    </Tooltip>
+    <Tooltip content="Left" placement="left" showArrow>
+      Left
+    </Tooltip>
+    <Tooltip content="Right" placement="right" showArrow>
+      Right
+    </Tooltip>
+  </div>
+);
+
 export const Disabled = () => (
   <div style={{ textAlign: 'center', width: '100%', margin: '50px' }}>
     <Tooltip content="Hi there" disabled={true}>

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useEffect,
   useMemo,
+  useCallback,
   ReactNode
 } from 'react';
 import { ConnectedOverlay, TriggerTypes } from '@/utils/Overlay';
@@ -125,9 +126,10 @@ export interface TooltipProps {
   pointerEvents?: string;
 
   /**
-   * Whether to show an arrow pointing from the tooltip to the trigger element.
+   * Arrow pointing from the tooltip to the trigger element.
+   * Pass `true` to render the default arrow, or a ReactNode to render a custom arrow.
    */
-  showArrow?: boolean;
+  arrow?: boolean | ReactNode;
 
   /**
    * Differentiator for popovers to be handled separate from tooltips
@@ -168,7 +170,7 @@ export const Tooltip: FC<TooltipProps> = ({
   closeOnEscape = true,
   closeOnBodyClick = true,
   pointerEvents = 'none',
-  showArrow = false,
+  arrow,
   modifiers,
   isPopover,
   onOpen,
@@ -182,12 +184,14 @@ export const Tooltip: FC<TooltipProps> = ({
   const [internalVisible, setInternalVisible] = useState<boolean>(visible);
   const timeout = useRef<any | null>(null);
   const mounted = useRef<boolean>(false);
-  const arrowRef = useRef<HTMLElement | null>(null);
+  const arrowRef = useRef<HTMLDivElement | null>(null);
   const arrowDataRef = useRef<{
     x?: number;
     y?: number;
     placement: string;
   } | null>(null);
+
+  const showArrow = !!arrow;
 
   const effectiveModifiers = useMemo(() => {
     if (!showArrow) return modifiers;
@@ -240,6 +244,35 @@ export const Tooltip: FC<TooltipProps> = ({
   }, [deactivateTooltip, isPopover, visible]);
 
   const theme: TooltipTheme = useComponentTheme('tooltip', customTheme);
+
+  const renderArrow = useCallback(() => {
+    if (!showArrow) {
+      return null;
+    }
+
+    const data = arrowDataRef.current;
+    const side = data?.placement?.split('-')[0] ?? placement.split('-')[0];
+    const staticSide = ARROW_STATIC_SIDE[side];
+    const arrowSize =
+      arrowRef.current?.offsetWidth ?? arrowRef.current?.offsetHeight ?? 8;
+    const isDefault = arrow === true;
+
+    return (
+      <div
+        ref={arrowRef}
+        className={isDefault ? theme.arrow : undefined}
+        style={{
+          position: 'absolute',
+          visibility: data ? 'visible' : 'hidden',
+          left: data?.x != null ? data.x : '',
+          top: data?.y != null ? data.y : '',
+          [staticSide]: -arrowSize / 2
+        }}
+      >
+        {isDefault ? null : arrow}
+      </div>
+    );
+  }, [showArrow, arrow, placement, theme.arrow]);
 
   return (
     <ConnectedOverlay
@@ -301,26 +334,7 @@ export const Tooltip: FC<TooltipProps> = ({
             }}
           >
             {contentChildren}
-            {showArrow &&
-              (() => {
-                const data = arrowDataRef.current;
-                const side =
-                  data?.placement?.split('-')[0] ?? placement.split('-')[0];
-                const staticSide = ARROW_STATIC_SIDE[side];
-                return (
-                  <div
-                    ref={arrowRef as React.Ref<HTMLDivElement>}
-                    className={theme.arrow}
-                    style={{
-                      position: 'absolute',
-                      visibility: data ? 'visible' : 'hidden',
-                      left: data?.x != null ? data.x : '',
-                      top: data?.y != null ? data.y : '',
-                      [staticSide]: -4
-                    }}
-                  />
-                );
-              })()}
+            {renderArrow()}
           </motion.div>
         );
       }}

--- a/src/layers/Tooltip/Tooltip.tsx
+++ b/src/layers/Tooltip/Tooltip.tsx
@@ -1,10 +1,31 @@
-import React, { FC, useState, useRef, useEffect, ReactNode } from 'react';
+import React, {
+  FC,
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  ReactNode
+} from 'react';
 import { ConnectedOverlay, TriggerTypes } from '@/utils/Overlay';
 import { Modifiers, Placement, ReferenceObject } from '@/utils/Position';
 import { motion, MotionNodeAnimationOptions } from 'motion/react';
+import {
+  arrow as arrowMiddleware,
+  offset,
+  flip,
+  shift,
+  limitShift
+} from '@floating-ui/react';
 import { useTooltipState } from './useTooltipState';
 import { TooltipTheme } from './TooltipTheme';
 import { cn, useComponentTheme } from '@/utils';
+
+const ARROW_STATIC_SIDE: Record<string, string> = {
+  top: 'bottom',
+  right: 'left',
+  bottom: 'top',
+  left: 'right'
+};
 
 export interface TooltipProps {
   /**
@@ -104,6 +125,11 @@ export interface TooltipProps {
   pointerEvents?: string;
 
   /**
+   * Whether to show an arrow pointing from the tooltip to the trigger element.
+   */
+  showArrow?: boolean;
+
+  /**
    * Differentiator for popovers to be handled separate from tooltips
    */
   isPopover?: boolean;
@@ -142,6 +168,8 @@ export const Tooltip: FC<TooltipProps> = ({
   closeOnEscape = true,
   closeOnBodyClick = true,
   pointerEvents = 'none',
+  showArrow = false,
+  modifiers,
   isPopover,
   onOpen,
   onClose,
@@ -154,6 +182,34 @@ export const Tooltip: FC<TooltipProps> = ({
   const [internalVisible, setInternalVisible] = useState<boolean>(visible);
   const timeout = useRef<any | null>(null);
   const mounted = useRef<boolean>(false);
+  const arrowRef = useRef<HTMLElement | null>(null);
+  const arrowDataRef = useRef<{
+    x?: number;
+    y?: number;
+    placement: string;
+  } | null>(null);
+
+  const effectiveModifiers = useMemo(() => {
+    if (!showArrow) return modifiers;
+    const base = modifiers || [flip(), shift({ limiter: limitShift() })];
+    return [
+      offset(8),
+      ...base,
+      arrowMiddleware({ element: arrowRef, padding: 8 }),
+      {
+        name: 'arrowCapture',
+        fn(state: any) {
+          arrowDataRef.current = {
+            x: state.middlewareData.arrow?.x,
+            y: state.middlewareData.arrow?.y,
+            placement: state.placement
+          };
+          return {};
+        }
+      }
+    ];
+  }, [showArrow, modifiers]);
+
   const ref = useRef<(setter: boolean, isPop?: boolean) => boolean>(
     (vis, isPop) => {
       // Since Popovers use the Tooltip component and they share state, need to differentiate between
@@ -196,6 +252,7 @@ export const Tooltip: FC<TooltipProps> = ({
       open={internalVisible}
       closeOnBodyClick={closeOnBodyClick}
       closeOnEscape={closeOnEscape}
+      modifiers={effectiveModifiers}
       content={() => {
         const contentChildren =
           typeof content === 'function' ? content() : content;
@@ -207,7 +264,7 @@ export const Tooltip: FC<TooltipProps> = ({
         return (
           <motion.div
             role={isPopover ? undefined : 'tooltip'}
-            className={cn(theme.base, className)}
+            className={cn(theme.base, showArrow && 'relative', className)}
             {...(animation
               ? animation
               : {
@@ -244,6 +301,26 @@ export const Tooltip: FC<TooltipProps> = ({
             }}
           >
             {contentChildren}
+            {showArrow &&
+              (() => {
+                const data = arrowDataRef.current;
+                const side =
+                  data?.placement?.split('-')[0] ?? placement.split('-')[0];
+                const staticSide = ARROW_STATIC_SIDE[side];
+                return (
+                  <div
+                    ref={arrowRef as React.Ref<HTMLDivElement>}
+                    className={theme.arrow}
+                    style={{
+                      position: 'absolute',
+                      visibility: data ? 'visible' : 'hidden',
+                      left: data?.x != null ? data.x : '',
+                      top: data?.y != null ? data.y : '',
+                      [staticSide]: -4
+                    }}
+                  />
+                );
+              })()}
           </motion.div>
         );
       }}

--- a/src/layers/Tooltip/TooltipTheme.ts
+++ b/src/layers/Tooltip/TooltipTheme.ts
@@ -1,7 +1,7 @@
 export interface TooltipTheme {
   base: string;
   disablePointer: string;
-  arrow: string;
+  arrow?: string;
 }
 
 const baseTheme: TooltipTheme = {

--- a/src/layers/Tooltip/TooltipTheme.ts
+++ b/src/layers/Tooltip/TooltipTheme.ts
@@ -1,11 +1,13 @@
 export interface TooltipTheme {
   base: string;
   disablePointer: string;
+  arrow: string;
 }
 
 const baseTheme: TooltipTheme = {
   base: 'whitespace-nowrap text-center will-change-[transform,opacity] p-1.5 rounded-sm',
-  disablePointer: 'pointer-events-none'
+  disablePointer: 'pointer-events-none',
+  arrow: 'w-2 h-2 rotate-45 bg-inherit'
 };
 
 export const tooltipTheme: TooltipTheme = {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

# Tooltip Arrow Feature

## What

Added `showArrow` prop to `Tooltip`. When enabled, renders a small triangular indicator pointing from the tooltip toward the trigger element.

```tsx
<Tooltip content="Hello" showArrow>Hover me</Tooltip>
```

## Changed Files

- **`Tooltip.tsx`** — New `showArrow` prop. Injects floating-ui `arrow()` + `offset(8)` middleware via the existing `modifiers` pipeline. A custom `arrowCapture` middleware stores positioning data in a ref so the arrow element renders at the correct edge/offset. No changes to shared overlay infrastructure.
- **`TooltipTheme.ts`** — Added `arrow` theme property (default: `'w-2 h-2 rotate-45 bg-inherit'`).
- **`Tooltip.story.tsx`** — Added `WithArrow` story with all four placements.

## Key Decisions

- **Self-contained via capture middleware** — Instead of modifying `ConnectedOverlayContent` to expose `middlewareData`, a small middleware writes arrow data to a ref the Tooltip already owns.
- **Ref over state** — Avoids infinite render loops since middleware runs inside layout effects. Data is available on the next render triggered by `floatingStyles` changing.
- **`visibility: hidden` on first render** — Arrow element must exist in DOM for the middleware to measure it, but data isn't available yet. Hidden until positioned.
- **Respects `flip()`** — The capture middleware reads `state.placement` (resolved after flip), so the arrow moves to the correct side automatically.


<img width="379" height="186" alt="Screenshot 2026-04-16 at 12 39 38" src="https://github.com/user-attachments/assets/d603b2ec-9eaf-47ea-bc14-104b101c2491" />
<img width="391" height="142" alt="Screenshot 2026-04-16 at 12 41 19" src="https://github.com/user-attachments/assets/f60fe31c-211d-4e61-88db-5321ac6fadf7" />
<img width="427" height="142" alt="Screenshot 2026-04-16 at 12 41 22" src="https://github.com/user-attachments/assets/a35eff09-81d9-4982-8566-b74b25b1a8f6" />
<img width="332" height="175" alt="Screenshot 2026-04-16 at 12 41 26" src="https://github.com/user-attachments/assets/94fa4ef4-0584-40a8-8a6a-d665aa9650d6" />
