### PR TITLE
ConfirmDialog: add destructive prop

### DIFF
--- a/src/layers/ConfirmDialog/ConfirmDialog.story.tsx
+++ b/src/layers/ConfirmDialog/ConfirmDialog.story.tsx
@@ -69,3 +69,55 @@ export const Default: Story = {
     cancelLabel: 'Cancel'
   }
 };
+
+export const Destructive: Story = {
+  render: args => {
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+
+    const handleConfirm = useCallback(
+      function (): void {
+        if (args.onConfirm) {
+          args.onConfirm();
+        }
+        setIsOpen(false);
+      },
+      [args, setIsOpen]
+    );
+
+    const handleCancel = useCallback(
+      function (): void {
+        if (args.onCancel) {
+          args.onCancel();
+        }
+        setIsOpen(false);
+      },
+      [args, setIsOpen]
+    );
+
+    return (
+      <>
+        <Button
+          onClick={function (): void {
+            setIsOpen(true);
+          }}
+        >
+          Delete Item
+        </Button>
+        <ConfirmDialog
+          {...args}
+          open={isOpen}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      </>
+    );
+  },
+  args: {
+    header: 'Delete Item',
+    content:
+      'Are you sure you want to delete this item? This action cannot be undone.',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Cancel',
+    destructive: true
+  }
+};

--- a/src/layers/ConfirmDialog/ConfirmDialog.story.tsx
+++ b/src/layers/ConfirmDialog/ConfirmDialog.story.tsx
@@ -118,6 +118,6 @@ export const Destructive: Story = {
       'Are you sure you want to delete this item? This action cannot be undone.',
     confirmLabel: 'Delete',
     cancelLabel: 'Cancel',
-    destructive: true
+    variant: 'destructive'
   }
 };

--- a/src/layers/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/layers/ConfirmDialog/ConfirmDialog.tsx
@@ -38,6 +38,11 @@ export interface ConfirmDialogProps {
    * Callback when the cancel button is clicked
    */
   onCancel?: () => void;
+
+  /**
+   * Whether the confirm action is destructive. When true, the confirm button uses the error color.
+   */
+  destructive?: boolean;
 }
 
 export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
@@ -47,14 +52,19 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   onConfirm,
-  onCancel
+  onCancel,
+  destructive = false
 }) => (
   <Dialog open={open} onClose={onCancel} header={header}>
     {() => (
       <>
         <div className="mb-6">{content}</div>
         <footer className="flex justify-end space-x-4">
-          <Button className="px-4 py-2" onClick={onConfirm} color="primary">
+          <Button
+            className="px-4 py-2"
+            onClick={onConfirm}
+            color={destructive ? 'error' : 'primary'}
+          >
             {confirmLabel}
           </Button>
           <Button className="px-4 py-2" onClick={onCancel}>

--- a/src/layers/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/layers/ConfirmDialog/ConfirmDialog.tsx
@@ -40,10 +40,18 @@ export interface ConfirmDialogProps {
   onCancel?: () => void;
 
   /**
-   * Whether the confirm action is destructive. When true, the confirm button uses the error color.
+   * The visual variant of the dialog. Use `destructive` for actions like delete.
    */
-  destructive?: boolean;
+  variant?: 'default' | 'destructive';
 }
+
+const VARIANT_COLORS: Record<
+  NonNullable<ConfirmDialogProps['variant']>,
+  'primary' | 'error'
+> = {
+  default: 'primary',
+  destructive: 'error'
+};
 
 export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   open,
@@ -53,7 +61,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   cancelLabel = 'Cancel',
   onConfirm,
   onCancel,
-  destructive = false
+  variant = 'default'
 }) => (
   <Dialog open={open} onClose={onCancel} header={header}>
     {() => (
@@ -63,7 +71,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
           <Button
             className="px-4 py-2"
             onClick={onConfirm}
-            color={destructive ? 'error' : 'primary'}
+            color={VARIANT_COLORS[variant]}
           >
             {confirmLabel}
           </Button>


### PR DESCRIPTION
## Summary
- Add optional `destructive` prop to `ConfirmDialog` that switches the confirm button color to `error` when true (defaults to `primary`)
- Add `Destructive` Storybook story showcasing a delete confirmation flow

<img width="1728" height="988" alt="Screenshot 2026-05-06 at 13 45 27" src="https://github.com/user-attachments/assets/9b2a88c4-2648-444d-8a6f-06d10b3e3159" />
