### PR TITLE
[Chore] Refactor story files to use inline icon component to prevent crash on reablocks website when reusing

### DIFF
--- a/src/form/Select/MultiSelect.story.tsx
+++ b/src/form/Select/MultiSelect.story.tsx
@@ -1,10 +1,21 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { FC, Fragment, useEffect, useState } from 'react';
 import { Select } from './Select';
 import { SelectOption } from './SelectOption';
 import { SelectMenu } from './SelectMenu';
 import { SelectInput, SelectInputChip } from './SelectInput';
 
-import CheckIcon from '@/assets/icons/check_circle.svg?react';
+const CheckIcon: FC<{ className?: string }> = ({ className }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path d="M7.99998 1.33337C4.31998 1.33337 1.33331 4.32004 1.33331 8.00004C1.33331 11.68 4.31998 14.6667 7.99998 14.6667C11.68 14.6667 14.6666 11.68 14.6666 8.00004C14.6666 4.32004 11.68 1.33337 7.99998 1.33337ZM7.99998 13.3334C5.05998 13.3334 2.66665 10.94 2.66665 8.00004C2.66665 5.06004 5.05998 2.66671 7.99998 2.66671C10.94 2.66671 13.3333 5.06004 13.3333 8.00004C13.3333 10.94 10.94 13.3334 7.99998 13.3334ZM11.06 5.05337L6.66665 9.44671L4.93998 7.72671L3.99998 8.66671L6.66665 11.3334L12 6.00004L11.06 5.05337Z" />
+  </svg>
+);
 
 export default {
   title: 'Components/Form/Select/Multi',

--- a/src/layers/Callout/Callout.story.tsx
+++ b/src/layers/Callout/Callout.story.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { Small } from '@/typography';
 
 import {
@@ -9,7 +9,21 @@ import {
   InfoCallout
 } from '@/layers';
 
-import CalendarIcon from '@/assets/icons/calendar.svg?react';
+const CalendarIcon: FC<{ className?: string }> = ({ className }) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <path
+      d="M12.6667 2.66671H12V1.33337H10.6667V2.66671H5.33333V1.33337H4V2.66671H3.33333C2.59333 2.66671 2.00667 3.26671 2.00667 4.00004L2 13.3334C2 14.0667 2.59333 14.6667 3.33333 14.6667H12.6667C13.4 14.6667 14 14.0667 14 13.3334V4.00004C14 3.26671 13.4 2.66671 12.6667 2.66671ZM12.6667 13.3334H3.33333V6.66671H12.6667V13.3334ZM12.6667 5.33337H3.33333V4.00004H12.6667V5.33337ZM6 9.33337H4.66667V8.00004H6V9.33337ZM8.66667 9.33337H7.33333V8.00004H8.66667V9.33337ZM11.3333 9.33337H10V8.00004H11.3333V9.33337ZM6 12H4.66667V10.6667H6V12ZM8.66667 12H7.33333V10.6667H8.66667V12ZM11.3333 12H10V10.6667H11.3333V12Z"
+      fill="currentColor"
+    />
+  </svg>
+);
 
 export default {
   title: 'Components/Layers/Callout',


### PR DESCRIPTION
… reablocks website when reusing

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`import CalendarIcon from '@/assets/icons/calendar.svg?react';`
this imports transform to 
`import CalendarIcon from 'reablocks';`
and that story is crashing because no valid import
Issue Number: N/A


## What is the new behavior?
Used inline component to make story independent on repository local files

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
