### PR TITLE
Ellipsis: Support Typography children + line-clamp truncation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reablocks",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reablocks",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",

--- a/src/data/Ellipsis/Ellipsis.story.tsx
+++ b/src/data/Ellipsis/Ellipsis.story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Ellipsis } from './Ellipsis';
+import { P, H3, Muted, H4, Lead, Small, H5 } from '@/typography';
 
 export default {
   title: 'Components/Data/Ellipsis',
@@ -8,14 +9,61 @@ export default {
 
 const words = `Integer a aliquet ligula. Fusce vel eros libero. Sed dictum tincidunt hendrerit. Integer id neque faucibus, imperdiet purus dapibus, rutrum tellus. Nullam facilisis odio sit amet metus efficitur, varius pellentesque lectus placerat. Integer non magna in justo cursus vestibulum sit amet ut odio. Pellentesque consectetur volutpat lectus ut gravida. In in urna eu felis malesuada pretium.`;
 
-export const Simple = () => <Ellipsis value={words} />;
+export const Simple = () => <Ellipsis value={words} title={words} />;
 
-export const Short = () => <Ellipsis value="A short sentence." />;
+export const Short = () => (
+  <Ellipsis value="A short sentence." title="A short sentence." />
+);
 
-export const Unexpandable = () => <Ellipsis expandable={false} value={words} />;
+export const Unexpandable = () => (
+  <Ellipsis expandable={false} value={words} title={words} />
+);
 
 export const Lines = () => (
   <div style={{ width: '250px' }}>
-    <Ellipsis lines={3} value={words} />
+    <Ellipsis lines={3} value={words} title={words} />
   </div>
+);
+
+export const WithTypographyP = () => (
+  <div style={{ width: '250px' }}>
+    <Ellipsis lines={3} title={words}>
+      <P>{words}</P>
+    </Ellipsis>
+  </div>
+);
+
+export const WithTypographyH4 = () => (
+  <div style={{ width: '300px' }}>
+    <Ellipsis lines={2} title={words}>
+      <H4>{words}</H4>
+    </Ellipsis>
+  </div>
+);
+
+export const WithTypographyMuted = () => (
+  <div style={{ width: '200px' }}>
+    <Ellipsis lines={4} title={words}>
+      <Muted>{words}</Muted>
+    </Ellipsis>
+  </div>
+);
+
+export const WithMixedTypography = () => (
+  <div style={{ width: '400px' }}>
+    <Ellipsis
+      lines={4}
+      title={`A complex React composition. This block consists of multiple typography components. ${words} End of the block.`}
+    >
+      <H5>A complex React composition.</H5>
+      <Muted>
+        This block consists of multiple typography components. {words}
+      </Muted>
+      <Small>End of the block.</Small>
+    </Ellipsis>
+  </div>
+);
+
+export const CharacterLimit = () => (
+  <Ellipsis limit={80} value={words} title={words} />
 );

--- a/src/data/Ellipsis/Ellipsis.story.tsx
+++ b/src/data/Ellipsis/Ellipsis.story.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Ellipsis } from './Ellipsis';
+import { EllipsisButton } from './EllipsisButton';
 import { P, H3, Muted, H4, Lead, Small, H5 } from '@/typography';
 
 export default {
@@ -66,4 +67,37 @@ export const WithMixedTypography = () => (
 
 export const CharacterLimit = () => (
   <Ellipsis limit={80} value={words} title={words} />
+);
+
+export const CustomButtonLabel = () => (
+  <div style={{ width: '300px' }}>
+    <Ellipsis lines={2} title={words}>
+      <P>{words}</P>
+      <EllipsisButton>Read full description</EllipsisButton>
+    </Ellipsis>
+  </div>
+);
+
+export const CustomButtonRender = () => (
+  <div style={{ width: '300px' }}>
+    <Ellipsis lines={2} title={words}>
+      <P>{words}</P>
+      <EllipsisButton>
+        {({ showAll, toggleExpand }) => (
+          <div style={{ marginTop: 4 }}>
+            <a
+              href="#"
+              onClick={event => {
+                event.preventDefault();
+                toggleExpand(event);
+              }}
+              style={{ color: '#6366f1', cursor: 'pointer' }}
+            >
+              {showAll ? '← Collapse' : 'Read more →'}
+            </a>
+          </div>
+        )}
+      </EllipsisButton>
+    </Ellipsis>
+  </div>
 );

--- a/src/data/Ellipsis/Ellipsis.tsx
+++ b/src/data/Ellipsis/Ellipsis.tsx
@@ -1,19 +1,25 @@
 import React, {
+  Children,
   FC,
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-  useMemo,
+  MouseEvent,
   ReactNode,
-  Children
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
 } from 'react';
 import ellipsize from 'ellipsize';
 import { EllipsisTheme } from './EllipsisTheme';
-import { useComponentTheme, cn } from '@/utils';
+import {
+  useComponentTheme,
+  cn,
+  hasSlotComponents,
+  extractSlots
+} from '@/utils';
 import { Tooltip } from '@/layers/Tooltip';
-import { Button } from '@/elements/Button';
-import { Divider } from '@/layout/Divider';
+import { EllipsisContext, EllipsisContextValue } from './EllipsisContext';
+import { EllipsisButton } from './EllipsisButton';
 
 export interface EllipsisProps {
   /**
@@ -104,7 +110,26 @@ export const Ellipsis: FC<EllipsisProps> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const theme: EllipsisTheme = useComponentTheme('ellipsis', customTheme);
 
-  const hasChildren = Children.count(children) > 0;
+  // Detect EllipsisButton slot and split it out from the content children.
+  const useSlots = useMemo(
+    () => hasSlotComponents(children, ['EllipsisButton']),
+    [children]
+  );
+
+  const slots = useMemo(
+    () =>
+      useSlots
+        ? extractSlots<{ button: ReactNode }>(children, {
+            EllipsisButton: 'button'
+          })
+        : null,
+    [useSlots, children]
+  );
+
+  const contentChildren: ReactNode = slots ? slots.other : children;
+  const hasChildren = slots
+    ? slots.other.length > 0
+    : Children.count(children) > 0;
 
   const substr = useMemo(() => {
     if (hasChildren) return '';
@@ -148,10 +173,10 @@ export const Ellipsis: FC<EllipsisProps> = ({
     };
   }, [checkTruncation]);
 
-  const toggleExpand = (event: React.MouseEvent) => {
+  const toggleExpand = useCallback((event: MouseEvent) => {
     event.stopPropagation();
-    setShowAll(!showAll);
-  };
+    setShowAll(prev => !prev);
+  }, []);
 
   // Resolve Truncation Active
   const renderButton = expandable && (isTruncated || showAll);
@@ -159,9 +184,9 @@ export const Ellipsis: FC<EllipsisProps> = ({
   const appliedLines = lines ?? 1;
 
   // Decide what to render inside the wrapper
-  let content;
+  let content: ReactNode;
   if (hasChildren) {
-    content = children;
+    content = contentChildren;
   } else if (lines !== undefined) {
     // CSS line-clamp handles truncation natively, render the full value
     content = value;
@@ -173,51 +198,37 @@ export const Ellipsis: FC<EllipsisProps> = ({
   const finalTooltip =
     title !== false ? title || (!hasChildren ? value : null) : null;
 
+  const contextValue: EllipsisContextValue = useMemo(
+    () => ({ showAll, isTruncated, toggleExpand, moreText, lessText }),
+    [showAll, isTruncated, toggleExpand, moreText, lessText]
+  );
+
   return (
-    <div className={cn(theme.base, className)}>
-      <Tooltip
-        arrow
-        className={cn(theme.tooltip, tooltipClassName)}
-        content={
-          isTruncated && !showAll && finalTooltip ? (
-            <div className={theme.tooltipContent}>{finalTooltip}</div>
-          ) : null
-        }
-        enterDelay={tooltipEnterDelay}
-      >
-        <div
-          ref={contentRef}
-          className={cn(theme.content.base, {
-            [`line-clamp-${appliedLines}`]:
-              (hasChildren || lines !== undefined) && !showAll,
-            [theme.content.truncated]: expandable && isTruncated && !showAll
-          })}
+    <EllipsisContext.Provider value={contextValue}>
+      <div className={cn(theme.base, className)}>
+        <Tooltip
+          arrow
+          className={cn(theme.tooltip, tooltipClassName)}
+          content={
+            isTruncated && !showAll && finalTooltip ? (
+              <div className={theme.tooltipContent}>{finalTooltip}</div>
+            ) : null
+          }
+          enterDelay={tooltipEnterDelay}
         >
-          {content}
-        </div>
-      </Tooltip>
-      {renderButton && (
-        <div
-          className={cn(
-            theme.buttonContainer.base,
-            !showAll
-              ? theme.buttonContainer.collapsed
-              : theme.buttonContainer.expanded
-          )}
-        >
-          <Divider disableMargins className={theme.buttonContainer.divider} />
-          <Button
-            variant="text"
-            size="small"
-            disableMargins
-            className={theme.buttonContainer.expandButton}
-            onClick={toggleExpand}
+          <div
+            ref={contentRef}
+            className={cn(theme.content.base, {
+              [`line-clamp-${appliedLines}`]:
+                (hasChildren || lines !== undefined) && !showAll,
+              [theme.content.truncated]: expandable && isTruncated && !showAll
+            })}
           >
-            {showAll ? lessText : moreText}
-          </Button>
-          <Divider disableMargins className={theme.buttonContainer.divider} />
-        </div>
-      )}
-    </div>
+            {content}
+          </div>
+        </Tooltip>
+        {renderButton && (slots?.button ?? <EllipsisButton />)}
+      </div>
+    </EllipsisContext.Provider>
   );
 };

--- a/src/data/Ellipsis/Ellipsis.tsx
+++ b/src/data/Ellipsis/Ellipsis.tsx
@@ -5,7 +5,8 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
-  ReactNode
+  ReactNode,
+  Children
 } from 'react';
 import ellipsize from 'ellipsize';
 import { EllipsisTheme } from './EllipsisTheme';
@@ -100,23 +101,25 @@ export const Ellipsis: FC<EllipsisProps> = ({
   const [showAll, setShowAll] = useState<boolean>(false);
   const [isTruncated, setIsTruncated] = useState<boolean>(false);
 
-  const modernRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const theme: EllipsisTheme = useComponentTheme('ellipsis', customTheme);
 
-  const hasChildren = React.Children.count(children) > 0;
+  const hasChildren = Children.count(children) > 0;
 
   const substr = useMemo(() => {
+    if (hasChildren) return '';
     const formatted = removeLinebreaks
       ? value.replace(/(\r\n|\n|\r)/gm, ' ')
       : value;
+
     return ellipsize(formatted, limit, { ellipse: '...' });
-  }, [limit, value, removeLinebreaks]);
+  }, [hasChildren, limit, value, removeLinebreaks]);
 
   const isCharTruncated =
     !hasChildren && lines === undefined && substr.length !== value.length;
 
   const checkTruncation = useCallback(() => {
-    const el = modernRef.current;
+    const el = contentRef.current;
     if (!el) return;
 
     let truncated = false;
@@ -132,7 +135,7 @@ export const Ellipsis: FC<EllipsisProps> = ({
   useEffect(() => {
     checkTruncation();
 
-    const el = modernRef.current;
+    const el = contentRef.current;
     if (!el) return;
 
     const resizeObserver = new ResizeObserver(() => {
@@ -153,16 +156,18 @@ export const Ellipsis: FC<EllipsisProps> = ({
   // Resolve Truncation Active
   const renderButton = expandable && (isTruncated || showAll);
 
-  const appliedLines = lines || 1;
+  const appliedLines = lines ?? 1;
 
   // Decide what to render inside the wrapper
   let content;
   if (hasChildren) {
     content = children;
   } else if (lines !== undefined) {
-    content = showAll ? value : value; // CSS line-clamp handles the text natively
+    // CSS line-clamp handles truncation natively, render the full value
+    content = value;
   } else {
-    content = showAll ? value : substr; // Character limit handles text
+    // Character limit path — swap to full value when expanded
+    content = showAll ? value : substr;
   }
 
   const finalTooltip =
@@ -181,17 +186,12 @@ export const Ellipsis: FC<EllipsisProps> = ({
         enterDelay={tooltipEnterDelay}
       >
         <div
-          ref={modernRef}
+          ref={contentRef}
           className={cn(theme.content.base, {
             [`line-clamp-${appliedLines}`]:
               (hasChildren || lines !== undefined) && !showAll,
             [theme.content.truncated]: expandable && isTruncated && !showAll
           })}
-          style={{
-            ...((hasChildren || lines !== undefined) && !showAll
-              ? { WebkitLineClamp: appliedLines.toString() }
-              : {})
-          }}
         >
           {content}
         </div>

--- a/src/data/Ellipsis/Ellipsis.tsx
+++ b/src/data/Ellipsis/Ellipsis.tsx
@@ -4,17 +4,32 @@ import React, {
   useRef,
   useEffect,
   useCallback,
-  useMemo
+  useMemo,
+  ReactNode
 } from 'react';
 import ellipsize from 'ellipsize';
 import { EllipsisTheme } from './EllipsisTheme';
-import { useComponentTheme } from '@/utils';
+import { useComponentTheme, cn } from '@/utils';
+import { Tooltip } from '@/layers/Tooltip';
+import { Button } from '@/elements/Button';
+import { Divider } from '@/layout/Divider';
 
 export interface EllipsisProps {
   /**
-   * The value to ellipsis.
+   * The value to ellipsis. Optional if children are provided.
+   * @deprecated Use `children` instead.
    */
-  value: string;
+  value?: string;
+
+  /**
+   * Children components for CSS-based truncation.
+   */
+  children?: ReactNode;
+
+  /**
+   * Class name for the tooltip.
+   */
+  tooltipClassName?: string;
 
   /**
    * Whether you can expand or not. Default: true.
@@ -27,9 +42,14 @@ export interface EllipsisProps {
   limit?: number;
 
   /**
-   * The title text to show on the hover.
+   * The title text to show on the hover in the Tooltip.
    */
   title?: string | false;
+
+  /**
+   * Delay in milliseconds before showing the tooltip. Default: 200.
+   */
+  tooltipEnterDelay?: number;
 
   /**
    * Remove line breaks or not.
@@ -63,118 +83,140 @@ export interface EllipsisProps {
 }
 
 export const Ellipsis: FC<EllipsisProps> = ({
-  value,
+  value = '',
+  children,
+  tooltipClassName,
   className,
   title,
+  tooltipEnterDelay = 200,
   removeLinebreaks = true,
   expandable = true,
   limit = 256,
   lines,
-  moreText = '...',
+  moreText = 'Show more',
   lessText = 'Show less',
   theme: customTheme
 }) => {
-  const [expanded, setExpanded] = useState<boolean>(false);
+  const [showAll, setShowAll] = useState<boolean>(false);
   const [isTruncated, setIsTruncated] = useState<boolean>(false);
-  const [isMeasured, setIsMeasured] = useState<boolean>(false);
-  const [truncatedText, setTruncatedText] = useState<string>(value);
-  const contentRef = useRef<HTMLDivElement>(null);
+
+  const modernRef = useRef<HTMLDivElement>(null);
   const theme: EllipsisTheme = useComponentTheme('ellipsis', customTheme);
+
+  const hasChildren = React.Children.count(children) > 0;
 
   const substr = useMemo(() => {
     const formatted = removeLinebreaks
       ? value.replace(/(\r\n|\n|\r)/gm, ' ')
       : value;
-    return ellipsize(formatted, limit, { ellipse: expandable ? '' : '...' });
-  }, [expandable, limit, value, removeLinebreaks]);
+    return ellipsize(formatted, limit, { ellipse: '...' });
+  }, [limit, value, removeLinebreaks]);
 
-  const measureText = useCallback(() => {
-    if (lines === undefined) {
-      if (substr.length !== value.length) {
-        setTruncatedText(substr);
-        setIsTruncated(true);
-      }
-      setIsMeasured(true);
-      return;
-    }
+  const isCharTruncated =
+    !hasChildren && lines === undefined && substr.length !== value.length;
 
-    if (!contentRef.current) {
-      return;
-    }
+  const checkTruncation = useCallback(() => {
+    const el = modernRef.current;
+    if (!el) return;
 
-    const content = contentRef.current;
-    const lineHeight = parseInt(window.getComputedStyle(content).lineHeight);
-    const maxHeight = lines ? lineHeight * lines : content.clientHeight;
-
-    content.style.maxHeight = `${maxHeight}px`;
-    content.style.overflow = 'hidden';
-
-    let truncated = value;
-    content.textContent = truncated + moreText;
-
-    if (content.scrollHeight > maxHeight) {
-      setIsTruncated(true);
-      while (content.scrollHeight > maxHeight && truncated.length > 0) {
-        truncated = truncated.slice(0, -1).trim();
-        content.textContent = truncated + moreText;
-      }
-      setTruncatedText(truncated);
+    let truncated = false;
+    if (hasChildren || lines !== undefined) {
+      truncated = el.scrollHeight > el.clientHeight;
     } else {
-      setIsTruncated(false);
-      setTruncatedText(value);
+      truncated = isCharTruncated;
     }
 
-    content.style.maxHeight = '';
-    content.style.overflow = '';
-    setIsMeasured(true);
-  }, [lines, value, moreText, substr]);
+    setIsTruncated(truncated);
+  }, [hasChildren, lines, isCharTruncated]);
 
   useEffect(() => {
-    // NOTE: The contentRef is used to measure the text. It must be a child of the parent element
-    // and positioned as a block element (div). The contentRef is not used to render the text due
-    // to the way wrapping works in CSS.
-    measureText();
-    if (lines !== undefined && typeof window !== 'undefined') {
-      window.addEventListener('resize', measureText);
-      return () => window.removeEventListener('resize', measureText);
-    }
-  }, [measureText, lines]);
+    checkTruncation();
+
+    const el = modernRef.current;
+    if (!el) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      checkTruncation();
+    });
+    resizeObserver.observe(el);
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [checkTruncation]);
 
   const toggleExpand = (event: React.MouseEvent) => {
     event.stopPropagation();
-    setExpanded(!expanded);
+    setShowAll(!showAll);
   };
 
+  // Resolve Truncation Active
+  const renderButton = expandable && (isTruncated || showAll);
+
+  const appliedLines = lines || 1;
+
+  // Decide what to render inside the wrapper
+  let content;
+  if (hasChildren) {
+    content = children;
+  } else if (lines !== undefined) {
+    content = showAll ? value : value; // CSS line-clamp handles the text natively
+  } else {
+    content = showAll ? value : substr; // Character limit handles text
+  }
+
+  const finalTooltip =
+    title !== false ? title || (!hasChildren ? value : null) : null;
+
   return (
-    <div className={className}>
-      {!isMeasured && lines !== undefined && (
-        <div ref={contentRef} className="invisible">
-          {value}
+    <div className={cn(theme.base, className)}>
+      <Tooltip
+        arrow
+        className={cn(theme.tooltip, tooltipClassName)}
+        content={
+          isTruncated && !showAll && finalTooltip ? (
+            <div className={theme.tooltipContent}>{finalTooltip}</div>
+          ) : null
+        }
+        enterDelay={tooltipEnterDelay}
+      >
+        <div
+          ref={modernRef}
+          className={cn(theme.content.base, {
+            [`line-clamp-${appliedLines}`]:
+              (hasChildren || lines !== undefined) && !showAll,
+            [theme.content.truncated]: expandable && isTruncated && !showAll
+          })}
+          style={{
+            ...((hasChildren || lines !== undefined) && !showAll
+              ? { WebkitLineClamp: appliedLines.toString() }
+              : {})
+          }}
+        >
+          {content}
         </div>
-      )}
-      {isMeasured && (
-        <>
-          <span title={title !== false ? title || value : undefined}>
-            {expanded ? value : truncatedText}
-          </span>
-          {expandable && isTruncated && (
-            <>
-              {expanded ? ' ' : ''}
-              <button
-                type="button"
-                title={
-                  expanded
-                    ? 'Click to show less'
-                    : 'Click to view rest of content'
-                }
-                className={theme.dots}
-                onClick={toggleExpand}
-              >
-                {expanded ? lessText : moreText}
-              </button>
-            </>
+      </Tooltip>
+      {renderButton && (
+        <div
+          className={cn(
+            theme.buttonContainer.base,
+            !showAll
+              ? theme.buttonContainer.collapsed
+              : theme.buttonContainer.expanded
           )}
-        </>
+        >
+          <Divider disableMargins className={theme.buttonContainer.divider} />
+          <Button
+            variant="text"
+            size="small"
+            disableMargins
+            className={theme.buttonContainer.expandButton}
+            onClick={toggleExpand}
+          >
+            {showAll ? lessText : moreText}
+          </Button>
+          <Divider disableMargins className={theme.buttonContainer.divider} />
+        </div>
       )}
     </div>
   );

--- a/src/data/Ellipsis/EllipsisButton.tsx
+++ b/src/data/Ellipsis/EllipsisButton.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import React, { FC, MouseEvent, ReactNode } from 'react';
+import { cn, useComponentTheme } from '@/utils';
+import { Button } from '@/elements/Button';
+import { Divider } from '@/layout/Divider';
+import { EllipsisTheme } from './EllipsisTheme';
+import { EllipsisContextValue, useEllipsisContext } from './EllipsisContext';
+
+export interface EllipsisButtonProps {
+  /**
+   * Custom button content. Accepts either a ReactNode (replaces the default
+   * label inside the default Button) or a function that receives the Ellipsis
+   * state and returns the entire button block.
+   */
+  children?: ReactNode | ((args: EllipsisContextValue) => ReactNode);
+
+  /**
+   * Class name applied to the outer container.
+   */
+  className?: string;
+
+  /**
+   * Override the expand label. When omitted, inherits from the parent
+   * Ellipsis component via context.
+   */
+  moreText?: string;
+
+  /**
+   * Override the collapse label. When omitted, inherits from the parent
+   * Ellipsis component via context.
+   */
+  lessText?: string;
+
+  /**
+   * Override the toggle handler. When omitted, inherits from the parent
+   * Ellipsis component via context.
+   */
+  onToggle?: (event: MouseEvent) => void;
+
+  /**
+   * Theme for the Ellipsis (used to style the default container).
+   */
+  theme?: EllipsisTheme;
+}
+
+/**
+ * Slot component that overrides the default expand/collapse button block in
+ * an Ellipsis. Detected via `displayName`; state is read from `EllipsisContext`
+ * provided by the parent `Ellipsis` component.
+ */
+export const EllipsisButton: FC<EllipsisButtonProps> = ({
+  children,
+  className,
+  moreText: moreTextProp,
+  lessText: lessTextProp,
+  onToggle: onToggleProp,
+  theme: customTheme
+}) => {
+  const context = useEllipsisContext();
+  const theme: EllipsisTheme = useComponentTheme('ellipsis', customTheme);
+
+  // Prop → context → default. Matches DialogHeader's merge convention.
+  const moreText = moreTextProp ?? context.moreText;
+  const lessText = lessTextProp ?? context.lessText;
+  const toggleExpand = onToggleProp ?? context.toggleExpand;
+  const { showAll, isTruncated } = context;
+
+  if (typeof children === 'function') {
+    return (
+      <>
+        {children({ showAll, isTruncated, toggleExpand, moreText, lessText })}
+      </>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        theme.buttonContainer.base,
+        !showAll
+          ? theme.buttonContainer.collapsed
+          : theme.buttonContainer.expanded,
+        className
+      )}
+    >
+      <Divider disableMargins className={theme.buttonContainer.divider} />
+      <Button
+        variant="text"
+        size="small"
+        disableMargins
+        className={theme.buttonContainer.expandButton}
+        onClick={toggleExpand}
+      >
+        {children ?? (showAll ? lessText : moreText)}
+      </Button>
+      <Divider disableMargins className={theme.buttonContainer.divider} />
+    </div>
+  );
+};
+
+EllipsisButton.displayName = 'EllipsisButton';

--- a/src/data/Ellipsis/EllipsisContext.tsx
+++ b/src/data/Ellipsis/EllipsisContext.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { MouseEvent, createContext, useContext } from 'react';
+
+export interface EllipsisContextValue {
+  /**
+   * Whether the content is currently expanded to show all.
+   */
+  showAll: boolean;
+
+  /**
+   * Whether the content is currently truncated.
+   */
+  isTruncated: boolean;
+
+  /**
+   * Toggle between expanded and collapsed state.
+   */
+  toggleExpand: (event: MouseEvent) => void;
+
+  /**
+   * Label used for the expand action.
+   */
+  moreText: string;
+
+  /**
+   * Label used for the collapse action.
+   */
+  lessText: string;
+}
+
+export const EllipsisContext = createContext<EllipsisContextValue | null>(null);
+
+/**
+ * Hook to access the Ellipsis context. Must be used within an Ellipsis component.
+ */
+export const useEllipsisContext = () => {
+  const context = useContext(EllipsisContext);
+  if (!context) {
+    throw new Error(
+      'Ellipsis compound components must be used within an Ellipsis component'
+    );
+  }
+  return context;
+};

--- a/src/data/Ellipsis/EllipsisTheme.ts
+++ b/src/data/Ellipsis/EllipsisTheme.ts
@@ -1,9 +1,67 @@
 export interface EllipsisTheme {
-  dots: string;
+  /**
+   * Outer container applied to the component.
+   */
+  base: string;
+
+  /**
+   * The text content wrapper configuration.
+   */
+  content: {
+    /**
+     * Base styling for the content wrapper.
+     */
+    base: string;
+
+    /**
+     * Classes added when truncation is active (e.g. gradient fade mask).
+     */
+    truncated: string;
+  };
+
+  /**
+   * Configuration for the container holding the "Show more/less" button and dividers.
+   */
+  buttonContainer: {
+    base: string;
+    collapsed: string;
+    expanded: string;
+    divider: string;
+    /**
+     * Expand/collapse button (the "..." / "Show less" control).
+     */
+    expandButton: string;
+  };
+
+  /**
+   * Class applied to the rich tooltip popover when `tooltip` is provided.
+   */
+  tooltip: string;
+
+  /**
+   * The inner wrapper for the tooltip content.
+   */
+  tooltipContent: string;
 }
 
 const baseTheme: EllipsisTheme = {
-  dots: 'cursor-pointer opacity-50 text-[unset] p-0 border-[none] outline-hidden'
+  base: 'relative group break-all',
+  content: {
+    base: 'min-w-0 w-full transition-all duration-300 wrap-break-word',
+    truncated:
+      'mask-[linear-gradient(to_bottom,black_50%,transparent_100%)] mask-size-[100%_200%] mask-position-[0_0] group-hover:mask-position-[0_100%]'
+  },
+  buttonContainer: {
+    base: 'w-full flex flex-row items-center justify-center pointer-events-none',
+    collapsed:
+      'absolute bottom-0 left-0 translate-y-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pt-8',
+    expanded: 'mt-0',
+    divider: 'flex-1 opacity-40 drop-shadow-md',
+    expandButton:
+      'cursor-pointer text-[unset] p-0 border-[none] outline-hidden shrink-0 whitespace-nowrap mx-2 pointer-events-auto drop-shadow-md'
+  },
+  tooltip: 'max-w-[600px] w-auto',
+  tooltipContent: 'text-inherit w-full whitespace-normal'
 };
 
 export const ellipsisTheme: EllipsisTheme = {

--- a/src/data/Ellipsis/index.ts
+++ b/src/data/Ellipsis/index.ts
@@ -1,2 +1,4 @@
 export * from './Ellipsis';
+export * from './EllipsisButton';
+export * from './EllipsisContext';
 export * from './EllipsisTheme';

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source inline("line-clamp-{1..10}");
 
 /* Color palette */
 :root,

--- a/src/layers/Tooltip/TooltipTheme.ts
+++ b/src/layers/Tooltip/TooltipTheme.ts
@@ -5,7 +5,7 @@ export interface TooltipTheme {
 }
 
 const baseTheme: TooltipTheme = {
-  base: 'whitespace-nowrap text-center will-change-[transform,opacity] p-1.5 rounded-sm',
+  base: 'whitespace-normal break-words text-center will-change-[transform,opacity] p-1.5 rounded-sm',
   disablePointer: 'pointer-events-none',
   arrow: 'w-2 h-2 rotate-45 bg-inherit'
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

Enable rendering arbitrary React elements — primarily Typography components (`P`, `H1`–`H6`, `Lead`, `Muted`, `Small`, …) and mixed compositions — inside `Ellipsis`, instead of only a plain `string`. This is the shape consumers actually need in practice: real product content is styled and often combines multiple typography blocks, not raw text.

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Migration notes

- `value` still works but is deprecated. New code should pass content as children:
  ```tsx
  // before
  <Ellipsis value="Long text..." lines={3} />

  // after
  <Ellipsis lines={3}>
    <P>Long text...</P>
  </Ellipsis>
  ```
- Tooltip text now comes from the `title` prop (or `value` fallback when no children); `title={false}` opts out.
- Consumers who customized `theme.dots` must migrate to `theme.buttonContainer.expandButton`.


## Other information

### `src/data/Ellipsis/Ellipsis.tsx` — refactor of the truncation strategy

- **New `children` prop** (`ReactNode`). When children are provided, Ellipsis truncates them via CSS instead of slicing a string.
- **Deprecated `value`** prop (kept for backwards compatibility, marked `@deprecated`).
- **CSS line-clamp** replaces the previous JS-based char-by-char measurement loop. Truncation is now driven by `line-clamp-${lines}` on the content wrapper, which works for any DOM subtree (nested typography, inline elements, etc.).
- **`ResizeObserver`** detects whether the content actually overflows (`scrollHeight > clientHeight`) and toggles the truncated state — replaces the manual `window.resize` listener.
- **Rich `Tooltip`** replaces the native `title=""` HTML attribute. Tooltip content is rendered only when the text is actually truncated and not expanded.
- **New props**: `tooltipClassName`, `tooltipEnterDelay` (default `200ms`).
- **Expand/collapse affordance** restyled — `Button variant="text"` flanked by two `Divider`s, revealed on hover via a gradient fade mask over the truncated content. Default `moreText` changed from `'...'` → `'Show more'`.

## Slot usage

```tsx
// Default
<Ellipsis lines={3}>{content}</Ellipsis>

// Full custom render
<Ellipsis lines={3}>
  <P>{content}</P>
  <EllipsisButton>
    {({ showAll, toggleExpand }) => (
      <a onClick={toggleExpand}>{showAll ? '← Collapse' : 'Read more →'}</a>
    )}
  </EllipsisButton>
</Ellipsis>
```

<img width="714" height="238" alt="Screenshot 2026-05-19 at 13 06 47" src="https://github.com/user-attachments/assets/fe8c9281-40e6-4dff-a045-0834ec85f275" />
<img width="1022" height="466" alt="Screenshot 2026-05-19 at 13 06 51" src="https://github.com/user-attachments/assets/96d0b2b3-44f8-43d2-a2ab-7f8aed9bebde" />
<img width="706" height="348" alt="Screenshot 2026-05-19 at 13 06 56" src="https://github.com/user-attachments/assets/db16f864-442b-4d6d-973b-b1316c7c47e8" />
