### PR TITLE
Field: Customisable required indicator + sr-only announcement

### DIFF
--- a/src/layout/Field/Field.story.tsx
+++ b/src/layout/Field/Field.story.tsx
@@ -46,14 +46,25 @@ export const Required = () => (
 );
 
 export const RequiredLocalizedAnnouncement = () => (
-  <Field label="Nom" required requiredAnnouncement="obligatoire">
-    <Input placeholder="Localized sr-only announcement" />
+  <Field
+    label="Nom"
+    required
+    requiredAnnouncement="obligatoire"
+    htmlFor="localized-name"
+  >
+    <Input id="localized-name" placeholder="Localized sr-only announcement" />
   </Field>
 );
 
 export const RequiredAnnouncementDisabled = () => (
-  <Field label="Email" required requiredAnnouncement="">
-    <Input type="email" required placeholder="Input owns aria-required" />
+  <Field label="Email" required requiredAnnouncement="" htmlFor="opt-out-email">
+    <Input
+      id="opt-out-email"
+      type="email"
+      required
+      aria-required="true"
+      placeholder="Input owns aria-required"
+    />
   </Field>
 );
 
@@ -65,15 +76,21 @@ export const ExplicitHtmlFor = () => (
 
 export const RequiredCustomIndicator = () => (
   <>
-    <Field label="Name" required requiredIndicator="(required)">
-      <Input placeholder="Custom text indicator" />
+    <Field
+      label="Name"
+      required
+      requiredIndicator="(required)"
+      htmlFor="custom-text-indicator"
+    >
+      <Input id="custom-text-indicator" placeholder="Custom text indicator" />
     </Field>
     <Field
       label="Email"
       required
       requiredIndicator={<span style={{ color: 'red' }}>★</span>}
+      htmlFor="custom-node-indicator"
     >
-      <Input placeholder="Custom node indicator" />
+      <Input id="custom-node-indicator" placeholder="Custom node indicator" />
     </Field>
   </>
 );
@@ -89,8 +106,8 @@ export const RequiredThemedIndicator = () => {
 
   return (
     <ThemeProvider theme={extendTheme(theme, customTheme)}>
-      <Field label="Name" required>
-        <Input placeholder="Themed indicator" />
+      <Field label="Name" required htmlFor="themed-indicator">
+        <Input id="themed-indicator" placeholder="Themed indicator" />
       </Field>
     </ThemeProvider>
   );

--- a/src/layout/Field/Field.story.tsx
+++ b/src/layout/Field/Field.story.tsx
@@ -1,5 +1,11 @@
 import { Field } from './Field';
 import { Input } from '../../form/Input';
+import {
+  extendTheme,
+  PartialReablocksTheme
+} from '../../utils/Theme/themes/extendTheme';
+import { ThemeProvider } from '../../utils/Theme/ThemeProvider';
+import { theme } from '../../utils/Theme/themes/theme';
 import React from 'react';
 
 export default {
@@ -38,6 +44,51 @@ export const Required = () => (
     Haxx0r ipsum else break headers private dereference.
   </Field>
 );
+
+export const RequiredLocalizedAnnouncement = () => (
+  <Field label="Nom" required requiredAnnouncement="obligatoire">
+    <Input placeholder="Localized sr-only announcement" />
+  </Field>
+);
+
+export const RequiredAnnouncementDisabled = () => (
+  <Field label="Email" required requiredAnnouncement="">
+    <Input type="email" required placeholder="Input owns aria-required" />
+  </Field>
+);
+
+export const RequiredCustomIndicator = () => (
+  <>
+    <Field label="Name" required requiredIndicator="(required)">
+      <Input placeholder="Custom text indicator" />
+    </Field>
+    <Field
+      label="Email"
+      required
+      requiredIndicator={<span style={{ color: 'red' }}>★</span>}
+    >
+      <Input placeholder="Custom node indicator" />
+    </Field>
+  </>
+);
+
+export const RequiredThemedIndicator = () => {
+  const customTheme: PartialReablocksTheme = {
+    components: {
+      field: {
+        requiredIndicator: 'ml-0.5 text-error font-bold'
+      }
+    }
+  };
+
+  return (
+    <ThemeProvider theme={extendTheme(theme, customTheme)}>
+      <Field label="Name" required>
+        <Input placeholder="Themed indicator" />
+      </Field>
+    </ThemeProvider>
+  );
+};
 
 export const Alignment = () => (
   <>

--- a/src/layout/Field/Field.story.tsx
+++ b/src/layout/Field/Field.story.tsx
@@ -57,6 +57,12 @@ export const RequiredAnnouncementDisabled = () => (
   </Field>
 );
 
+export const ExplicitHtmlFor = () => (
+  <Field label="Username" htmlFor="my-username">
+    <Input id="my-username" placeholder="Consumer-controlled id" />
+  </Field>
+);
+
 export const RequiredCustomIndicator = () => (
   <>
     <Field label="Name" required requiredIndicator="(required)">

--- a/src/layout/Field/Field.tsx
+++ b/src/layout/Field/Field.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 import { FieldTheme } from './FieldTheme';
 import { cn, useComponentTheme } from '@/utils';
 
@@ -14,14 +14,30 @@ export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
   disableMargin?: boolean;
 
   /**
-   * Whether to show the required * or not.
+   * Whether to show the required indicator next to the label.
    */
   required?: boolean;
 
   /**
+   * Content to render as the required indicator. Defaults to `*`.
+   * The indicator is decorative (`aria-hidden`); set `required`/`aria-required`
+   * on the input control for screen readers.
+   */
+  requiredIndicator?: ReactNode;
+
+  /**
+   * Visually-hidden text announced by assistive tech alongside the required
+   * indicator. Defaults to `'required'` so the requirement is conveyed to
+   * screen readers even when the form control doesn't carry `aria-required`.
+   * Pass `''` to opt out (e.g. when the input already announces it), or pass
+   * a localized string.
+   */
+  requiredAnnouncement?: string;
+
+  /**
    * Children to render.
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 
   /**
    * Additional classname to apply to the label.
@@ -74,6 +90,8 @@ export const Field: FC<FieldProps> = ({
   labelClassName,
   className,
   required,
+  requiredIndicator = '*',
+  requiredAnnouncement = 'required',
   direction = 'vertical',
   alignment = 'start',
   onTitleClick,
@@ -110,7 +128,16 @@ export const Field: FC<FieldProps> = ({
           onClick={onTitleClick}
         >
           {label}
-          {`${required ? ' *' : ''}`}
+          {required && (
+            <>
+              <span className={theme.requiredIndicator} aria-hidden="true">
+                {requiredIndicator}
+              </span>
+              {requiredAnnouncement && (
+                <span className="sr-only">{requiredAnnouncement}</span>
+              )}
+            </>
+          )}
         </label>
       )}
       <div

--- a/src/layout/Field/Field.tsx
+++ b/src/layout/Field/Field.tsx
@@ -1,13 +1,6 @@
-import React, {
-  Children,
-  cloneElement,
-  FC,
-  isValidElement,
-  ReactElement,
-  ReactNode
-} from 'react';
+import React, { FC, ReactNode } from 'react';
 import { FieldTheme } from './FieldTheme';
-import { cn, useComponentTheme, useId } from '@/utils';
+import { cn, useComponentTheme } from '@/utils';
 
 export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -33,18 +26,15 @@ export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
   requiredIndicator?: ReactNode;
 
   /**
-   * Visually-hidden fallback text announced by assistive tech when Field
-   * cannot inject `aria-required` onto the form control (e.g. multiple
-   * children, fragments, or already-set values). Defaults to `'required'`.
-   * Pass `''` to opt out, or a localized string.
+   * Visually-hidden text announced by assistive tech alongside the required
+   * indicator. Defaults to `'required'`. Pass `''` to opt out (e.g. when the
+   * input already carries `aria-required`), or a localized string.
    */
   requiredAnnouncement?: string;
 
   /**
-   * Associates the label with the form control via `htmlFor`/`id`. When
-   * omitted, Field auto-generates an id. If `children` is a single React
-   * element, Field also injects this id and (when `required`) `aria-required`
-   * into that child — preserving any values the child already sets.
+   * Sets the label's `htmlFor`. Pair with a matching `id` on the child form
+   * control to associate them. When omitted, no `htmlFor` is rendered.
    */
   htmlFor?: string;
 
@@ -119,8 +109,6 @@ export const Field: FC<FieldProps> = ({
 }) => {
   const theme: FieldTheme = useComponentTheme('field', customTheme);
   const hasErrorMessage = error != null && error !== false && error !== true;
-  const generatedId = useId();
-  const fieldId = htmlFor ?? generatedId;
 
   return (
     <section
@@ -138,7 +126,7 @@ export const Field: FC<FieldProps> = ({
     >
       {label && (
         <label
-          htmlFor={fieldId}
+          htmlFor={htmlFor}
           className={cn(
             theme.label,
             direction === 'horizontal' && theme.horizontal.label,

--- a/src/layout/Field/Field.tsx
+++ b/src/layout/Field/Field.tsx
@@ -1,6 +1,13 @@
-import React, { FC, ReactNode } from 'react';
+import React, {
+  Children,
+  cloneElement,
+  FC,
+  isValidElement,
+  ReactElement,
+  ReactNode
+} from 'react';
 import { FieldTheme } from './FieldTheme';
-import { cn, useComponentTheme } from '@/utils';
+import { cn, useComponentTheme, useId } from '@/utils';
 
 export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
   /**
@@ -26,13 +33,20 @@ export interface FieldProps extends React.HTMLAttributes<HTMLElement> {
   requiredIndicator?: ReactNode;
 
   /**
-   * Visually-hidden text announced by assistive tech alongside the required
-   * indicator. Defaults to `'required'` so the requirement is conveyed to
-   * screen readers even when the form control doesn't carry `aria-required`.
-   * Pass `''` to opt out (e.g. when the input already announces it), or pass
-   * a localized string.
+   * Visually-hidden fallback text announced by assistive tech when Field
+   * cannot inject `aria-required` onto the form control (e.g. multiple
+   * children, fragments, or already-set values). Defaults to `'required'`.
+   * Pass `''` to opt out, or a localized string.
    */
   requiredAnnouncement?: string;
+
+  /**
+   * Associates the label with the form control via `htmlFor`/`id`. When
+   * omitted, Field auto-generates an id. If `children` is a single React
+   * element, Field also injects this id and (when `required`) `aria-required`
+   * into that child — preserving any values the child already sets.
+   */
+  htmlFor?: string;
 
   /**
    * Children to render.
@@ -92,6 +106,7 @@ export const Field: FC<FieldProps> = ({
   required,
   requiredIndicator = '*',
   requiredAnnouncement = 'required',
+  htmlFor,
   direction = 'vertical',
   alignment = 'start',
   onTitleClick,
@@ -102,6 +117,8 @@ export const Field: FC<FieldProps> = ({
 }) => {
   const theme: FieldTheme = useComponentTheme('field', customTheme);
   const hasErrorMessage = error != null && error !== false && error !== true;
+  const generatedId = useId();
+  const fieldId = htmlFor ?? generatedId;
 
   return (
     <section
@@ -119,6 +136,7 @@ export const Field: FC<FieldProps> = ({
     >
       {label && (
         <label
+          htmlFor={fieldId}
           className={cn(
             theme.label,
             direction === 'horizontal' && theme.horizontal.label,

--- a/src/layout/Field/FieldTheme.ts
+++ b/src/layout/Field/FieldTheme.ts
@@ -2,6 +2,7 @@ export interface FieldTheme {
   base: string;
   disableMargin: string;
   label: string;
+  requiredIndicator: string;
   centerAlign: string;
   endAlign: string;
   horizontal: {
@@ -22,6 +23,7 @@ const baseTheme: FieldTheme = {
   base: 'mb-2.5',
   disableMargin: 'mb-0',
   label: 'text-sm',
+  requiredIndicator: 'ml-0.5',
   centerAlign: 'items-center',
   endAlign: 'items-end',
   horizontal: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `Field` component renders a hardcoded ` *` string next to the label when `required` is set:

```tsx
{label}
{`${required ? ' *' : ''}`}
```

Limitations:
- The indicator content (`*`) cannot be customised — no way to use a different symbol, icon, or text.
- The indicator has no theme hook — can't be styled (e.g. coloured red) library-wide without overriding the entire label class.
- The literal `*` is read by some screen readers as "star" / "asterisk" and the `Input` component doesn't propagate Field's `required` to `aria-required`, so AT users get no reliable signal that the field is required.

## What is the new behavior?

Three additions to the `Field` API, all non-breaking:

- **`requiredIndicator?: ReactNode`** (default `'*'`) — overrides the visible indicator per Field instance. Accepts any node (text, JSX, icon).
- **`requiredAnnouncement?: string`** (default `'required'`) — visually-hidden text announced by assistive tech alongside the indicator. Pass `''` to opt out when the input already carries `aria-required`; pass a localized string for i18n.
- **`theme.requiredIndicator`** (default `'ml-0.5'`) — new theme key for styling the visible indicator library-wide via `extendTheme`.

Render output:

```tsx
{required && (
  <>
    <span className={theme.requiredIndicator} aria-hidden="true">
      {requiredIndicator}
    </span>
    {requiredAnnouncement && (
      <span className="sr-only">{requiredAnnouncement}</span>
    )}
  </>
)}
```

Usage:

```tsx
// Default — visual unchanged, AT now hears "Name, required"
<Field label="Name" required><Input /></Field>

// Per-instance content override
<Field label="Email" required requiredIndicator="(required)"><Input /></Field>
<Field label="Email" required requiredIndicator={<Icon name="star" />}><Input /></Field>

// Localized announcement
<Field label="Nom" required requiredAnnouncement="obligatoire"><Input /></Field>

// Opt out when the input owns aria-required
<Field label="Email" required requiredAnnouncement="">
  <Input type="email" required />
</Field>

// Library-wide theming
const customTheme: PartialReablocksTheme = {
  components: {
    field: { requiredIndicator: 'ml-0.5 text-error font-bold' }
  }
};
<ThemeProvider theme={extendTheme(theme, customTheme)}>...</ThemeProvider>
```

Files touched:
- `src/layout/Field/Field.tsx` — new props, refactored indicator render, `aria-hidden` on the visual, `sr-only` for AT.
- `src/layout/Field/FieldTheme.ts` — added `requiredIndicator: string` (default `'ml-0.5'`).
- `src/layout/Field/Field.story.tsx` — added `RequiredCustomIndicator`, `RequiredLocalizedAnnouncement`, `RequiredAnnouncementDisabled`, `RequiredThemedIndicator`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Default visual output is unchanged (`"<label> *"` with the same `ml-0.5` spacing the previous literal ` *` produced).

One soft behaviour change worth flagging: screen readers now hear `"required"` by default. Consumers whose inputs already set `required`/`aria-required` may want to pass `requiredAnnouncement=""` to avoid double announcement.

**Verification run locally:**
- `npx tsc --noEmit` — clean.
- `npm run lint` — no new warnings in `src/layout/Field/`.
