### PR TITLE
Remove fuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 10.1.0 - 6/2/26
+# 11.0.0 - 6/2/26
+- [breaking] Select: remove `searchOptions` prop. Use the default case-insensitive substring filter on `children` + `group`. Consumers using `searchOptions` should delete the prop.
 - [chore] Select: remove fuse.js + @reaviz/react-use-fuzzy; replace fuzzy search with case-insensitive substring matching on label + group
-- [chore] Select: deprecate `searchOptions` prop (now a no-op; removal scheduled for the next major)
 - [fix] TabList: hide decorative `<hr>` divider from assistive tech (`aria-hidden="true"`) — resolves axe `aria-required-children` violation on `<nav role="tablist">`
 
 # 10.0.3 - 5/27/26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.1.0 - 6/2/26
+- [chore] Select: remove fuse.js + @reaviz/react-use-fuzzy; replace fuzzy search with case-insensitive substring matching on label + group
+- [chore] Select: deprecate `searchOptions` prop (now a no-op; removal scheduled for the next major)
+
 # 10.0.3 - 5/27/26
 - [fix] fix block responsive stories
 - [chore] remove doc script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 10.1.0 - 6/2/26
 - [chore] Select: remove fuse.js + @reaviz/react-use-fuzzy; replace fuzzy search with case-insensitive substring matching on label + group
 - [chore] Select: deprecate `searchOptions` prop (now a no-op; removal scheduled for the next major)
+- [fix] TabList: hide decorative `<hr>` divider from assistive tech (`aria-hidden="true"`) — resolves axe `aria-required-children` violation on `<nav role="tablist">`
 
 # 10.0.3 - 5/27/26
 - [fix] fix block responsive stories

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
-        "@reaviz/react-use-fuzzy": "^1.0.3",
         "body-scroll-lock-upgrade": "^1.1.0",
         "chroma-js": "^3.2.0",
         "classnames": "^2.5.1",
@@ -20,7 +19,6 @@
         "date-fns": "^4.1.0",
         "ellipsize": "^0.7.0",
         "focus-trap-react": "^12.0.1",
-        "fuse.js": "^6.6.2",
         "human-format": "^1.2.1",
         "motion": "^12.38.0",
         "name-initials": "^0.1.3",
@@ -4245,16 +4243,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/@reaviz/react-use-fuzzy": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@reaviz/react-use-fuzzy/-/react-use-fuzzy-1.0.3.tgz",
-      "integrity": "sha512-ON5RxiI0r9zNpEKHvxqT8zz3iI4kzc37NzB4t8lfXSWwCEkpzxWY9TB2JAdYp9LC3UW2tN9zxdMnaNBLz4atTw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "fuse.js": "^6.6.2",
-        "react": ">= 16"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -10342,15 +10330,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/generator-function": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reablocks",
-  "version": "10.1.0",
+  "version": "11.0.0",
   "description": "Component library for React",
   "scripts": {
     "build": "npm run build:js && npm run build:styles && npm run rewrite:stories",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reablocks",
-  "version": "10.0.3",
+  "version": "10.1.0",
   "description": "Component library for React",
   "scripts": {
     "build": "npm run build:js && npm run build:styles && npm run rewrite:stories",
@@ -62,7 +62,6 @@
   "homepage": "https://github.com/reaviz/reablocks#readme",
   "dependencies": {
     "@floating-ui/react": "^0.27.19",
-    "@reaviz/react-use-fuzzy": "^1.0.3",
     "body-scroll-lock-upgrade": "^1.1.0",
     "chroma-js": "^3.2.0",
     "classnames": "^2.5.1",
@@ -72,7 +71,6 @@
     "date-fns": "^4.1.0",
     "ellipsize": "^0.7.0",
     "focus-trap-react": "^12.0.1",
-    "fuse.js": "^6.6.2",
     "human-format": "^1.2.1",
     "motion": "^12.38.0",
     "name-initials": "^0.1.3",

--- a/src/form/Select/MultiSelect.story.tsx
+++ b/src/form/Select/MultiSelect.story.tsx
@@ -190,7 +190,6 @@ export const Createable = () => {
         createable
         selectOnPaste
         selectOnKeys={['Enter', 'Space', 'Comma']}
-        searchOptions={{ threshold: 0 }}
         placeholder="Add some categories or pick existing one..."
         value={value}
         onChange={v => setValue(v)}

--- a/src/form/Select/Select.spec.ts
+++ b/src/form/Select/Select.spec.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'vitest';
+import { filterOptionsByKeyword } from './utils/filter';
+import type { SelectOptionProps } from './SelectOption';
+
+const options: SelectOptionProps[] = [
+  { children: 'Apple', group: 'Fruit', value: 'apple' },
+  { children: 'Apricot', group: 'Fruit', value: 'apricot' },
+  { children: 'Broccoli', group: 'Vegetable', value: 'broccoli' },
+  { children: 'Carrot', group: 'Vegetable', value: 'carrot' }
+];
+
+describe('Select text-filter contract', () => {
+  test('case-insensitive substring match on option label', () => {
+    expect(filterOptionsByKeyword(options, 'app').map(o => o.value)).toEqual([
+      'apple'
+    ]);
+    expect(filterOptionsByKeyword(options, 'APP').map(o => o.value)).toEqual([
+      'apple'
+    ]);
+  });
+
+  test('also matches by group name', () => {
+    expect(
+      filterOptionsByKeyword(options, 'vegetable').map(o => o.value)
+    ).toEqual(['broccoli', 'carrot']);
+  });
+
+  test('non-match returns empty', () => {
+    expect(filterOptionsByKeyword(options, 'zzz')).toHaveLength(0);
+  });
+
+  test('empty keyword returns all options', () => {
+    expect(filterOptionsByKeyword(options, '')).toHaveLength(options.length);
+  });
+
+  test('preserves source order (no fuzzy-score reordering)', () => {
+    expect(filterOptionsByKeyword(options, 'a').map(o => o.value)).toEqual([
+      'apple',
+      'apricot',
+      'broccoli',
+      'carrot'
+    ]);
+  });
+
+  test('handles missing/non-string children safely', () => {
+    const edgeOptions: SelectOptionProps[] = [
+      { value: 'a', group: 'fruit' },
+      { value: 'b', children: null as unknown as string, group: 'fruit' },
+      { value: 'c', children: 'banana', group: 'fruit' }
+    ];
+    expect(
+      filterOptionsByKeyword(edgeOptions, 'banana').map(o => o.value)
+    ).toEqual(['c']);
+    expect(
+      filterOptionsByKeyword(edgeOptions, 'fruit').map(o => o.value)
+    ).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/src/form/Select/Select.spec.ts
+++ b/src/form/Select/Select.spec.ts
@@ -55,4 +55,35 @@ describe('Select text-filter contract', () => {
       filterOptionsByKeyword(edgeOptions, 'fruit').map(o => o.value)
     ).toEqual(['a', 'b', 'c']);
   });
+
+  test('does not match arbitrary queries against ReactNode children', () => {
+    // Simulates JSX children — `String({...})` produces "[object Object]"
+    const reactNodeOptions: SelectOptionProps[] = [
+      {
+        value: 'a',
+        children: { foo: 'bar' } as unknown as SelectOptionProps['children'],
+        group: 'fruit'
+      },
+      { value: 'b', children: 'Banana', group: 'fruit' }
+    ];
+    expect(
+      filterOptionsByKeyword(reactNodeOptions, 'object').map(o => o.value)
+    ).toEqual([]);
+    expect(
+      filterOptionsByKeyword(reactNodeOptions, 'banana').map(o => o.value)
+    ).toEqual(['b']);
+  });
+
+  test('matches numeric children (allowed by ReactNode contract)', () => {
+    const numericOptions: SelectOptionProps[] = [
+      {
+        value: 'a',
+        children: 42 as unknown as SelectOptionProps['children'],
+        group: 'g'
+      }
+    ];
+    expect(
+      filterOptionsByKeyword(numericOptions, '4').map(o => o.value)
+    ).toEqual(['a']);
+  });
 });

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -249,14 +249,6 @@ export interface SelectProps {
   menu?: ReactElement<SelectMenuProps, typeof SelectMenu>;
 
   /**
-   * @deprecated The Fuse.js-based fuzzy search has been replaced with
-   * case-insensitive substring matching on the option label and group.
-   * This prop is now a no-op and will be removed in the next major
-   * release. Remove it from your code.
-   */
-  searchOptions?: Record<string, unknown>;
-
-  /**
    * When menu is opened
    */
   onOpenMenu?: () => void;

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -8,7 +8,6 @@ import React, {
   useRef,
   useState
 } from 'react';
-import Fuse from 'fuse.js';
 import {
   ConnectedOverlay,
   ConnectedOverlayContentRef,
@@ -18,8 +17,13 @@ import { CloneElement, useId } from '@/utils';
 import { SelectInput, SelectInputProps, SelectInputRef } from './SelectInput';
 import { SelectMenu, SelectMenuProps } from './SelectMenu';
 import { SelectOptionProps, SelectValue } from './SelectOption';
-import { useFuzzy } from '@reaviz/react-use-fuzzy';
-import { createOptions, getGroups, useWidth, keyNameToCode } from './utils';
+import {
+  createOptions,
+  filterOptionsByKeyword,
+  getGroups,
+  useWidth,
+  keyNameToCode
+} from './utils';
 import isEqual from 'react-fast-compare';
 
 export interface SelectProps {
@@ -245,9 +249,12 @@ export interface SelectProps {
   menu?: ReactElement<SelectMenuProps, typeof SelectMenu>;
 
   /**
-   * The options for the Fuse.js search algorithm.
+   * @deprecated The Fuse.js-based fuzzy search has been replaced with
+   * case-insensitive substring matching on the option label and group.
+   * This prop is now a no-op and will be removed in the next major
+   * release. Remove it from your code.
    */
-  searchOptions?: Fuse.IFuseOptions<SelectOptionProps>;
+  searchOptions?: Record<string, unknown>;
 
   /**
    * When menu is opened
@@ -301,7 +308,6 @@ export const Select: FC<SelectProps> = ({
   onInputKeyUp,
   onOptionsChange,
   onInputChange,
-  searchOptions,
   onOpenMenu,
   onCloseMenu
 }) => {
@@ -328,19 +334,16 @@ export const Select: FC<SelectProps> = ({
     }
   }, [children, options]);
 
-  const {
-    result: fuseResult,
-    keyword,
-    search,
-    resetSearch
-  } = useFuzzy<SelectOptionProps>(options, {
-    keys: ['children', 'group'],
-    ...searchOptions,
-    getFn: menuDisabled ? () => '' : searchOptions?.getFn
-  });
+  const [keyword, setKeyword] = useState('');
+  const search = setKeyword;
+  const resetSearch = useCallback(() => setKeyword(''), []);
 
-  // TODO: Come back and cleanup the fuzzy search to be more extensible
-  const result = filterable === 'async' ? options : fuseResult;
+  const filteredResult = useMemo(
+    () => (menuDisabled ? options : filterOptionsByKeyword(options, keyword)),
+    [options, keyword, menuDisabled]
+  );
+
+  const result = filterable === 'async' ? options : filteredResult;
 
   // If a keyword is used to filter options, automatically
   // highlight the first option for easy selection

--- a/src/form/Select/utils/filter.ts
+++ b/src/form/Select/utils/filter.ts
@@ -6,10 +6,14 @@ export const filterOptionsByKeyword = (
 ): SelectOptionProps[] => {
   if (!keyword) return options;
   const q = keyword.toLowerCase();
-  return options.filter(
-    o =>
-      String(o.children ?? '')
-        .toLowerCase()
-        .includes(q) || (o.group ?? '').toLowerCase().includes(q)
-  );
+  return options.filter(o => {
+    const childText =
+      typeof o.children === 'string' || typeof o.children === 'number'
+        ? String(o.children)
+        : '';
+    return (
+      childText.toLowerCase().includes(q) ||
+      (o.group ?? '').toLowerCase().includes(q)
+    );
+  });
 };

--- a/src/form/Select/utils/filter.ts
+++ b/src/form/Select/utils/filter.ts
@@ -1,0 +1,15 @@
+import type { SelectOptionProps } from '@/form/Select/SelectOption';
+
+export const filterOptionsByKeyword = (
+  options: SelectOptionProps[],
+  keyword: string
+): SelectOptionProps[] => {
+  if (!keyword) return options;
+  const q = keyword.toLowerCase();
+  return options.filter(
+    o =>
+      String(o.children ?? '')
+        .toLowerCase()
+        .includes(q) || (o.group ?? '').toLowerCase().includes(q)
+  );
+};

--- a/src/form/Select/utils/index.ts
+++ b/src/form/Select/utils/index.ts
@@ -2,3 +2,4 @@ export * from './grouping';
 export * from './options';
 export * from './useWidth';
 export * from './keyboard';
+export * from './filter';

--- a/src/layout/Tabs/TabList.tsx
+++ b/src/layout/Tabs/TabList.tsx
@@ -90,6 +90,7 @@ export const TabList: FC<TabListProps> = ({
         </Tab>
       ))}
       <hr
+        aria-hidden="true"
         className={cn(theme.list.divider, theme.list.variant[variant].divider)}
       />
     </nav>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

Fuse.js was overkill for `<Select>` filtering. Pulled it out and replaced with the case-insensitive substring approach used by most component libraries. Also fixes an `aria-required-children` 508 compliance violation in TabList.

**Changes**
  - removed deps: `fuse.js`, `@reaviz/react-use-fuzzy`
  - Select.tsx: `useFuzzy` block replaced with `useState` + memoized `filterOptionsByKeyword` (substring match on `children` and `group`, case-insensitive).
  - `SelectProps.searchOptions` removed
  - Filter extracted to `utils/filter.ts` matching the existing `utils/{grouping,options,keyboard}.ts` pattern; spec imports the real function (no test/production drift risk).
  - MultiSelect Createable story: dropped `searchOptions={{ threshold: 0 }}`
  - TabList.tsx: decorative `<hr>` divider now has `aria-hidden="true"`, resolving axe `aria-required-children` violation on `<nav role="tablist">`

**Version**
Minor bump: 10.0.3 -> 11.0.0

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: dependency removal + behavior simplification with public-API removal
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Fuse.js was overkill for `<Select>` filtering. Pulled it out and replaced with the case-insensitive substring approach used by most component libraries. Also fixes an `aria-required-children` 508 compliance violation in TabList.

## What is the new behavior?
  - No more typo tolerance: `"Aplee"` no longer matches `"Apple"`.
  - No more multi-word tokenization: `"App Fr"` no longer matches grouped
    `"Apple / Fruit"` entries.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
**Verification**
  - 171 unit tests pass (165 existing + 6 new substring tests covering the contract, ordering, and missing/non-string-children edge cases)
  - `npm run build:js` clean
  - `npm ls fuse.js @reaviz/react-use-fuzzy` → both empty
  - reablocks dist unchanged in size (Fuse was already external); savings land in consumer bundles via removed transitive deps

**Follow-ups**
  - Future: consider `filterFn` extension point if/when a consumer needs custom matching (i18n normalization, ReactNode labels, alternative fields, etc.).