### PR TITLE
preserve existing chip on duplicate via Enter/blur

### DIFF
--- a/src/form/Select/MultiSelect.story.tsx
+++ b/src/form/Select/MultiSelect.story.tsx
@@ -373,6 +373,37 @@ export const CreateableNoOptions = () => {
   );
 };
 
+export const CreateableDuplicateRejected = () => {
+  const [value, setValue] = useState<string[]>([]);
+  const [options, setOptions] = useState<string[]>([]);
+  const [lastDuplicate, setLastDuplicate] = useState<string | null>(null);
+  return (
+    <div style={{ width: 300 }}>
+      <Select
+        multiple
+        createable
+        menuDisabled
+        placeholder="Add a tag, then try adding it again..."
+        value={value}
+        onOptionsChange={opts => setOptions(opts.map(o => o.value))}
+        onChange={v => setValue(v)}
+        onDuplicate={dupe => setLastDuplicate(dupe)}
+      >
+        {options.map(opt => (
+          <SelectOption key={opt} value={opt}>
+            {opt}
+          </SelectOption>
+        ))}
+      </Select>
+      {lastDuplicate && (
+        <div style={{ marginTop: 8, fontSize: 12, color: '#888' }}>
+          <code>"{lastDuplicate}"</code> already exists
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const Async = () => {
   const [value, setValue] = useState<string | null>('github');
   const [loading, setLoading] = useState<boolean>(false);

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -604,6 +604,10 @@ export const Select: FC<SelectProps> = ({
         return;
       }
 
+      if (menuDisabled && createable && !inputValue) {
+        return;
+      }
+
       if (index > -1 || createable) {
         let newSelection;
 

--- a/src/form/Select/Select.tsx
+++ b/src/form/Select/Select.tsx
@@ -217,6 +217,14 @@ export interface SelectProps {
   onClear?: () => void;
 
   /**
+   * When the user attempts to add a value that is already selected,
+   * via Enter or blur, in `createable` + `menuDisabled` mode. The
+   * duplicate is rejected and the input is reset; this callback lets
+   * consumers surface feedback (e.g. a toast).
+   */
+  onDuplicate?: (value: string) => void;
+
+  /**
    * When the value changes.
    */
   onChange?: (value) => void;
@@ -294,6 +302,7 @@ export const Select: FC<SelectProps> = ({
   onRefresh,
   onChange,
   onClear,
+  onDuplicate,
   onBlur: onInputBlur,
   onFocus: onInputFocus,
   onInputKeydown,
@@ -434,6 +443,12 @@ export const Select: FC<SelectProps> = ({
     setOpen(false);
     resetInput();
   }, [resetInput]);
+
+  const isSelected = useCallback(
+    (candidate: string): boolean =>
+      Array.isArray(value) ? value.includes(candidate) : value === candidate,
+    [value]
+  );
 
   const onArrowUpKeyUp = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -593,7 +608,7 @@ export const Select: FC<SelectProps> = ({
         let newSelection;
 
         const hasSelection = index > -1 && result[index];
-        if (createable && !hasSelection) {
+        if (createable && (menuDisabled || !hasSelection)) {
           newSelection = {
             value: inputValue,
             children: inputValue
@@ -604,22 +619,24 @@ export const Select: FC<SelectProps> = ({
         // Add new item if menu not disabled or item not presents in the list otherwise just clear input
         if (
           newSelection &&
-          (!menuDisabled || !value?.includes(newSelection.value))
+          (!menuDisabled || !isSelected(newSelection.value))
         ) {
           toggleSelectedOption(newSelection);
-        } else if (menuDisabled && value?.includes(newSelection.value)) {
+        } else if (menuDisabled && isSelected(newSelection.value)) {
           resetInput();
+          onDuplicate?.(newSelection.value);
         }
       }
     },
     [
       createable,
       index,
+      isSelected,
       menuDisabled,
+      onDuplicate,
       resetInput,
       result,
-      toggleSelectedOption,
-      value
+      toggleSelectedOption
     ]
   );
 
@@ -693,17 +710,28 @@ export const Select: FC<SelectProps> = ({
       const inputElement = event.target as HTMLInputElement;
       const inputValue = inputElement.value.trim();
       if (menuDisabled && createable && inputValue) {
-        const newSelection = {
-          value: inputValue,
-          children: inputValue
-        };
-
-        toggleSelectedOption(newSelection);
+        if (isSelected(inputValue)) {
+          resetInput();
+          onDuplicate?.(inputValue);
+        } else {
+          toggleSelectedOption({
+            value: inputValue,
+            children: inputValue
+          });
+        }
       }
 
       onInputBlur?.(event);
     },
-    [createable, menuDisabled, onInputBlur, toggleSelectedOption]
+    [
+      createable,
+      isSelected,
+      menuDisabled,
+      onDuplicate,
+      onInputBlur,
+      resetInput,
+      toggleSelectedOption
+    ]
   );
 
   const onPasteHandler = useCallback(


### PR DESCRIPTION
 In `createable` + `menuDisabled` mode (the freeform tag-input pattern), typing a value that's already selected and then **blurring** the input (Tab away, click elsewhere) silently removed the existing chip. The Enter path already guarded this case, but the blur path fell through to `toggleSelectedOption`, which is a symmetric add/remove — so adding a duplicate value removed the existing one. 
 
 While confirming the fix, found a second issue on the Enter path: when the keyword-auto-highlight effect sets `index = 0` and `menuDisabled` short-circuits filtering (so `result` is the full options list), `newSelection` was sourced from `result[index]` — the first option — instead of the user's typed value. The behavior happened to be visually correct (input cleared either way), but any `onDuplicate`-style callback would receive the wrong value.

  ## Fix
  - Mirror the Enter handler's dupe guard in `onInputBlured`.
  - In `createable + menuDisabled`, always source `newSelection` from the typed `inputValue`, never `result[index]`.
  - Extract `isSelected(candidate)` helper using `Array.isArray` to pick between array `.includes` and string equality.
  - New optional `onDuplicate?: (value: string) => void` prop, fired from both Enter and blur dupe-reject branches so consumers can surface feedback (e.g. a toast). No-op when omitted.
  - New Storybook story `CreateableDuplicateRejected` demonstrating the behavior + callback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Select keyboard/blur behavior and an optional callback; no auth or data-layer changes.
> 
> **Overview**
> Fixes **createable + menuDisabled** tag input so re-entering an already-selected value no longer removes the existing chip on blur, and Enter uses the typed text instead of a highlighted menu option when the menu is disabled.
> 
> **Blur** now matches Enter: if the trimmed input is already selected, the input clears and selection is unchanged; otherwise the value is added. **Enter** builds the new option from `inputValue` when `menuDisabled` (or when nothing is highlighted), fixing wrong values passed when keyword auto-highlight sets `index` to 0.
> 
> Adds **`isSelected`** for multi vs single value checks, optional **`onDuplicate`** when a duplicate is rejected on Enter or blur, and a **`CreateableDuplicateRejected`** Storybook story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3300e193f2aa66d624b63ac50d000617aa5091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->